### PR TITLE
feat: Multi-language indexing (--lang all), cache language validation, Windows tree-sitter DLL fix

### DIFF
--- a/tldr/daemon.py
+++ b/tldr/daemon.py
@@ -542,6 +542,7 @@ class TLDRDaemon:
                     {"from_file": e[0], "from_func": e[1], "to_file": e[2], "to_func": e[3]}
                     for e in graph.edges
                 ],
+                "languages": [language],
                 "timestamp": time.time(),
             }
             cache_file.write_text(json.dumps(cache_data, indent=2))

--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional
 
+ALL_LANGUAGES = ["python", "typescript", "javascript", "go", "rust", "java", "c", "cpp", "ruby", "php", "kotlin", "swift", "csharp", "scala", "lua", "elixir"]
+
 # Lazy imports for heavy dependencies
 _model = None
 _model_name = None  # Track which model is loaded
@@ -568,6 +570,7 @@ def _get_function_signature(file_path: Path, func_name: str, lang: str) -> Optio
 
                     return f"def {func_name}({', '.join(args)}){returns}"
 
+
         # For other languages, return simple signature
         return f"function {func_name}(...)"
 
@@ -607,6 +610,62 @@ def _get_progress_console():
         return Console()
     except ImportError:
         return None
+
+
+def _detect_project_languages(project_path: Path, respect_ignore: bool = True) -> List[str]:
+    """Scan project files to detect present languages."""
+    from tldr.tldrignore import load_ignore_patterns, should_ignore
+    
+    # Extension map (copied from cli.py to avoid circular import)
+    EXTENSION_TO_LANGUAGE = {
+        '.java': 'java',
+        '.py': 'python',
+        '.ts': 'typescript',
+        '.tsx': 'typescript',
+        '.js': 'javascript',
+        '.jsx': 'javascript',
+        '.go': 'go',
+        '.rs': 'rust',
+        '.c': 'c',
+        '.h': 'c',
+        '.cpp': 'cpp',
+        '.hpp': 'cpp',
+        '.cc': 'cpp',
+        '.cxx': 'cpp',
+        '.hh': 'cpp',
+        '.rb': 'ruby',
+        '.php': 'php',
+        '.swift': 'swift',
+        '.cs': 'csharp',
+        '.kt': 'kotlin',
+        '.kts': 'kotlin',
+        '.scala': 'scala',
+        '.sc': 'scala',
+        '.lua': 'lua',
+        '.ex': 'elixir',
+        '.exs': 'elixir',
+    }
+    
+    found_languages = set()
+    spec = load_ignore_patterns(project_path) if respect_ignore else None
+    
+    for root, dirs, files in os.walk(project_path):
+        # Prune common heavy dirs immediately for speed
+        dirs[:] = [d for d in dirs if d not in {'.git', 'node_modules', '.tldr', 'venv', '__pycache__', '.idea', '.vscode'}]
+        
+        for file in files:
+             file_path = Path(root) / file
+             
+             # Check ignore patterns
+             if respect_ignore and should_ignore(file_path, project_path, spec):
+                 continue
+                 
+             ext = file_path.suffix.lower()
+             if ext in EXTENSION_TO_LANGUAGE:
+                 found_languages.add(EXTENSION_TO_LANGUAGE[ext])
+
+    # Return sorted list intersect with ALL_LANGUAGES to ensure validity
+    return sorted(list(found_languages & set(ALL_LANGUAGES)))
 
 
 def build_semantic_index(
@@ -657,10 +716,33 @@ def build_semantic_index(
     # Extract all units (respecting .tldrignore)
     if console:
         with console.status("[bold green]Extracting code units...") as status:
-            units = extract_units_from_project(str(project), lang=lang, respect_ignore=respect_ignore)
+            if lang == "all":
+                # Optimization: detect which languages are actually present
+                status.update("[bold green]Scanning project languages...")
+                target_languages = _detect_project_languages(project, respect_ignore=respect_ignore)
+                if not target_languages:
+                    console.print("[yellow]No supported languages detected in project[/yellow]")
+                    return 0
+                if console:
+                    console.print(f"[dim]Detected languages: {', '.join(target_languages)}[/dim]")
+                
+                units = []
+                for lang_name in target_languages:
+                    status.update(f"[bold green]Extracting {lang_name} code units...")
+                    units.extend(extract_units_from_project(str(project), lang=lang_name, respect_ignore=respect_ignore))
+            else:
+                units = extract_units_from_project(str(project), lang=lang, respect_ignore=respect_ignore)
             status.update(f"[bold green]Extracted {len(units)} code units")
     else:
-        units = extract_units_from_project(str(project), lang=lang, respect_ignore=respect_ignore)
+        if lang == "all":
+            target_languages = _detect_project_languages(project, respect_ignore=respect_ignore)
+            if not target_languages:
+                return 0
+            units = []
+            for lang_name in target_languages:
+                units.extend(extract_units_from_project(str(project), lang=lang_name, respect_ignore=respect_ignore))
+        else:
+            units = extract_units_from_project(str(project), lang=lang, respect_ignore=respect_ignore)
 
     if not units:
         return 0


### PR DESCRIPTION
## Multi-language support for warm and semantic index with --lang all

### Summary

Adds `--lang all` option to [warm](cci:1://file:///c:/Users/rainsler/Desktop/OmiApp/llm-tldr/tldr/daemon.py:526:4-555:57) and `semantic index` commands, enabling multi-language project support. The implementation pre-scans projects to detect present languages (respecting `.tldrignore`), builds call graphs for each, and merges them into a unified cache with proper metadata for validation.

### Changes

**Multi-language indexing:**
- `tldr warm . --lang all` - Detects and indexes all supported languages in a project
- `tldr semantic index . --lang all` - Builds semantic embeddings across all detected languages
- Pre-scans project to detect only languages actually present (avoids processing unused languages)
- Merges call graphs from multiple languages into a single cache

**Cache consistency:**
- Added [languages](cci:1://file:///c:/Users/rainsler/Desktop/OmiApp/llm-tldr/tldr/semantic.py:614:0-667:61) metadata field to `call_graph.json` cache
- [_get_or_build_graph()](cci:1://file:///c:/Users/rainsler/Desktop/OmiApp/llm-tldr/tldr/cli.py:455:4-530:20) validates cache language compatibility - rebuilds if mismatch detected
- Prevents mixed-language graphs from being consumed as single-language
- Edge deduplication before caching

**Bug fixes:**
- Fixed [_get_function_signature()](cci:1://file:///c:/Users/rainsler/Desktop/OmiApp/llm-tldr/tldr/semantic.py:545:0-577:19) dropping unannotated function arguments (broke signature text for most Python code)
- Fixed Windows tree-sitter DLL loading failures (gated to `os.name == 'nt'`)

**Robustness improvements:**
- Added argparse `choices` validation for `--lang` argument
- Separated `ValueError` handling for unsupported languages
- Added `TLDR_DEBUG=1` environment variable for traceback on unexpected errors
- Empty language detection short-circuits gracefully
- Renamed loop variable `l` to `lang_name` (Ruff E741 compliance)

### Usage

```bash
# Index a multi-language project
tldr warm . --lang all

# Build semantic embeddings for all languages
tldr semantic index . --lang all

# Debug mode for troubleshooting
TLDR_DEBUG=1 tldr warm . --lang all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for processing multiple programming languages simultaneously with new "all" language option.
  * Automatic language detection for your project.

* **Bug Fixes**
  * Fixed Windows command-line compatibility issues.
  * Improved cache validation for language consistency.

* **Improvements**
  * Enhanced error handling for multi-language processing.
  * Better reporting with per-language indexing statistics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->