### PR TITLE
feat: enhance daemon query command with JSON support

### DIFF
--- a/tests/test_daemon_query.py
+++ b/tests/test_daemon_query.py
@@ -1,0 +1,284 @@
+"""Tests for daemon query command with --json flag.
+
+Tests for enhanced daemon query command that supports:
+- Simple command: tldr daemon query ping
+- JSON payload: tldr daemon query --json '{"cmd":"semantic",...}'
+- Error handling for invalid JSON
+- Error handling for missing arguments
+
+Note: These tests are for the --json flag feature added in commit d7ec148.
+Run these tests against the PR branch containing that commit, or apply the commit
+to verify the feature works correctly.
+
+Per PR requirements, all tests verify:
+- Valid JSON payload parsing and daemon submission
+- Invalid JSON error handling
+- Missing arguments error (neither cmd nor --json)
+- Both arguments provided (--json precedence)
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class TestDaemonQueryJsonFlag:
+    """Tests for daemon query command --json flag functionality."""
+
+    def test_query_with_valid_json_payload(self, capsys):
+        """Should parse and submit valid JSON payload to daemon."""
+        from tldr.cli import main
+
+        project_path = Path("/fake/project").resolve()
+        json_payload = '{"cmd": "semantic", "action": "search", "query": "test"}'
+        expected_response = {"status": "ok", "results": []}
+
+        # Create a mock function that returns expected_response
+        mock_query_func = MagicMock(return_value=expected_response)
+
+        # Patch the daemon module's query_daemon before main() runs
+        # We need to patch it in the tldr.daemon module, not cli
+        with patch("tldr.daemon.query_daemon", mock_query_func):
+            # Simulate CLI call: tldr daemon query --json '{"cmd": "semantic",...}'
+            test_args = [
+                "daemon",
+                "query",
+                "--json",
+                json_payload,
+                "--project",
+                str(project_path),
+            ]
+
+            with patch("sys.argv", ["tldr"] + test_args):
+                try:
+                    main()
+                except SystemExit:
+                    pass
+
+            # Verify query_daemon was called with parsed JSON
+            mock_query_func.assert_called_once()
+            called_with_project, called_with_command = mock_query_func.call_args[0]
+            assert called_with_project == project_path
+            assert called_with_command == json.loads(json_payload)
+
+            # Verify output is formatted JSON
+            captured = capsys.readouterr()
+            output = json.loads(captured.out)
+            assert output == expected_response
+
+    def test_query_with_simple_command(self, capsys):
+        """Should fall back to simple command when --json not provided."""
+        from tldr.cli import main
+
+        project_path = Path("/fake/project").resolve()
+        expected_response = {"status": "ok", "message": "pong"}
+
+        mock_query_func = MagicMock(return_value=expected_response)
+
+        with patch("tldr.daemon.query_daemon", mock_query_func):
+            # Simulate CLI call: tldr daemon query ping
+            test_args = ["daemon", "query", "ping", "--project", str(project_path)]
+
+            with patch("sys.argv", ["tldr"] + test_args):
+                try:
+                    main()
+                except SystemExit:
+                    pass
+
+            # Verify query_daemon was called with {"cmd": "ping"}
+            mock_query_func.assert_called_once()
+            called_with_project, called_with_command = mock_query_func.call_args[0]
+            assert called_with_project == project_path
+            assert called_with_command == {"cmd": "ping"}
+
+            # Verify output is formatted JSON
+            captured = capsys.readouterr()
+            output = json.loads(captured.out)
+            assert output == expected_response
+
+    def test_query_with_invalid_json_error(self, capsys):
+        """Should display error for invalid JSON in --json flag."""
+        from tldr.cli import main
+
+        project_path = Path("/fake/project").resolve()
+        invalid_json = '{"cmd": "semantic", invalid}'
+
+        mock_query_func = MagicMock()
+
+        with patch("tldr.daemon.query_daemon", mock_query_func):
+            # Simulate CLI call with invalid JSON
+            test_args = [
+                "daemon",
+                "query",
+                "--json",
+                invalid_json,
+                "--project",
+                str(project_path),
+            ]
+
+            with patch("sys.argv", ["tldr"] + test_args):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+            # Should exit with error code 1
+            assert exc_info.value.code == 1
+
+            # Verify query_daemon was NOT called
+            mock_query_func.assert_not_called()
+
+            # Verify error message contains JSON decode error
+            captured = capsys.readouterr()
+            assert "Error: invalid JSON for --json" in captured.err
+
+    def test_query_missing_both_arguments_error(self, capsys):
+        """Should display error when neither cmd nor --json is provided."""
+        from tldr.cli import main
+
+        project_path = Path("/fake/project").resolve()
+
+        mock_query_func = MagicMock()
+
+        with patch("tldr.daemon.query_daemon", mock_query_func):
+            # Simulate CLI call without cmd or --json
+            test_args = ["daemon", "query", "--project", str(project_path)]
+
+            with patch("sys.argv", ["tldr"] + test_args):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+            # Should exit with error code 1
+            assert exc_info.value.code == 1
+
+            # Verify query_daemon was NOT called
+            mock_query_func.assert_not_called()
+
+            # Verify error message
+            captured = capsys.readouterr()
+            assert "Error: either CMD or --json must be provided" in captured.err
+
+    def test_query_json_precedence_over_cmd(self, capsys):
+        """Should use --json payload and ignore cmd argument when both provided."""
+        from tldr.cli import main
+
+        project_path = Path("/fake/project").resolve()
+        json_payload = '{"cmd": "semantic", "action": "search"}'
+        expected_response = {"status": "ok", "results": []}
+
+        mock_query_func = MagicMock(return_value=expected_response)
+
+        with patch("tldr.daemon.query_daemon", mock_query_func):
+            # Simulate CLI call with both cmd and --json
+            # --json should take precedence
+            test_args = [
+                "daemon",
+                "query",
+                "ping",  # This should be ignored
+                "--json",
+                json_payload,  # This should be used
+                "--project",
+                str(project_path),
+            ]
+
+            with patch("sys.argv", ["tldr"] + test_args):
+                try:
+                    main()
+                except SystemExit:
+                    pass
+
+            # Verify query_daemon was called with JSON payload, not {"cmd": "ping"}
+            mock_query_func.assert_called_once()
+            called_with_project, called_with_command = mock_query_func.call_args[0]
+            assert called_with_project == project_path
+            assert called_with_command == json.loads(json_payload)
+            assert called_with_command != {"cmd": "ping"}
+
+    def test_query_complex_json_payload(self, capsys):
+        """Should handle complex nested JSON payloads."""
+        from tldr.cli import main
+
+        project_path = Path("/fake/project").resolve()
+        complex_json = json.dumps(
+            {
+                "cmd": "semantic",
+                "action": "search",
+                "query": "validate tokens",
+                "filters": {"language": "python", "min_tokens": 100},
+                "limit": 10,
+            }
+        )
+        expected_response = {
+            "status": "ok",
+            "results": [
+                {
+                    "file": "auth.py",
+                    "function": "verify_token",
+                    "score": 0.95,
+                }
+            ],
+        }
+
+        mock_query_func = MagicMock(return_value=expected_response)
+
+        with patch("tldr.daemon.query_daemon", mock_query_func):
+            test_args = [
+                "daemon",
+                "query",
+                "--json",
+                complex_json,
+                "--project",
+                str(project_path),
+            ]
+
+            with patch("sys.argv", ["tldr"] + test_args):
+                try:
+                    main()
+                except SystemExit:
+                    pass
+
+            # Verify complex payload was parsed correctly
+            mock_query_func.assert_called_once()
+            called_with_project, called_with_command = mock_query_func.call_args[0]
+            assert called_with_project == project_path
+            assert called_with_command == json.loads(complex_json)
+            assert called_with_command["filters"]["language"] == "python"
+            assert called_with_command["limit"] == 10
+
+    def test_query_json_with_special_characters(self, capsys):
+        """Should handle JSON with special characters and unicode."""
+        from tldr.cli import main
+
+        project_path = Path("/fake/project").resolve()
+        json_with_special = json.dumps(
+            {"cmd": "search", "query": "función 中文 🚀", "regex": "^test_.*"}
+        )
+        expected_response = {"status": "ok", "results": []}
+
+        mock_query_func = MagicMock(return_value=expected_response)
+
+        with patch("tldr.daemon.query_daemon", mock_query_func):
+            test_args = [
+                "daemon",
+                "query",
+                "--json",
+                json_with_special,
+                "--project",
+                str(project_path),
+            ]
+
+            with patch("sys.argv", ["tldr"] + test_args):
+                try:
+                    main()
+                except SystemExit:
+                    pass
+
+            # Verify special characters preserved
+            mock_query_func.assert_called_once()
+            _, called_with_command = mock_query_func.call_args[0]
+            assert called_with_command["query"] == "función 中文 🚀"
+            assert called_with_command["regex"] == "^test_.*"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_daemon_query.py
+++ b/tests/test_daemon_query.py
@@ -51,7 +51,7 @@ class TestDaemonQueryJsonFlag:
                 str(project_path),
             ]
 
-            with patch("sys.argv", ["tldr"] + test_args):
+            with patch("sys.argv", ["tldr", *test_args]):
                 try:
                     main()
                 except SystemExit:
@@ -158,7 +158,7 @@ class TestDaemonQueryJsonFlag:
             captured = capsys.readouterr()
             assert "Error: either CMD or --json must be provided" in captured.err
 
-    def test_query_json_precedence_over_cmd(self, capsys):
+    def test_query_json_precedence_over_cmd(self):
         """Should use --json payload and ignore cmd argument when both provided."""
         from tldr.cli import main
 
@@ -194,7 +194,7 @@ class TestDaemonQueryJsonFlag:
             assert called_with_command == json.loads(json_payload)
             assert called_with_command != {"cmd": "ping"}
 
-    def test_query_complex_json_payload(self, capsys):
+    def test_query_complex_json_payload(self):
         """Should handle complex nested JSON payloads."""
         from tldr.cli import main
 
@@ -245,7 +245,7 @@ class TestDaemonQueryJsonFlag:
             assert called_with_command["filters"]["language"] == "python"
             assert called_with_command["limit"] == 10
 
-    def test_query_json_with_special_characters(self, capsys):
+    def test_query_json_with_special_characters(self):
         """Should handle JSON with special characters and unicode."""
         from tldr.cli import main
 


### PR DESCRIPTION
Updated the `query` command in the daemon to accept a raw JSON payload via the `--json` flag, allowing for more complex commands. The command now also handles cases where either a simple command or JSON must be provided, improving error handling and user feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemon query command accepts an optional --json flag to submit raw JSON payloads; when omitted, a simple positional command is still supported. --json takes precedence if both provided.

* **Bug Fixes / Validation**
  * Improved handling and clear errors for invalid JSON and missing input when no JSON is provided.

* **Tests**
  * Added comprehensive tests covering valid/invalid JSON, fallback behavior, precedence, complex payloads, and special characters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Enhanced the `tldr daemon query` command to accept raw JSON payloads via a new `--json` flag, enabling more complex command structures beyond simple command names. The implementation includes proper error handling for invalid JSON and missing arguments.

**Changes:**
- Added `--json` argument to daemon query parser (lines 420-434)
- Modified `cmd` argument to be optional (`nargs="?"`) since `--json` can be used instead
- Implemented conditional logic to parse JSON payload or fall back to simple command structure (lines 1198-1218)
- Added JSON validation with `JSONDecodeError` handling
- Added validation to ensure either `cmd` or `--json` is provided

**Issues found:**
- Missing tests for new functionality (repository policy requires tests for all PRs)

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor concerns about test coverage
- The implementation is straightforward and handles error cases properly (invalid JSON, missing arguments). The logic correctly prioritizes `--json` over the positional `cmd` argument. However, the absence of tests per repository requirements prevents a score of 5.
- No files require special attention - the implementation is clean and well-structured

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tldr/cli.py | Added `--json` flag to daemon query command for accepting raw JSON payloads, improved error handling for missing arguments and invalid JSON |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as tldr CLI
    participant ArgParse as argparse
    participant QueryDaemon as query_daemon()
    participant Daemon as TLDRDaemon

    User->>CLI: tldr daemon query --json '{"cmd":"semantic","action":"search"}'
    CLI->>ArgParse: Parse arguments
    ArgParse-->>CLI: args (cmd=None, json='{"cmd":"semantic",...}')
    
    alt --json flag provided
        CLI->>CLI: json.loads(args.json)
        alt JSON valid
            CLI->>CLI: command = parsed JSON
        else JSON invalid
            CLI->>User: Error: invalid JSON for --json
            CLI->>CLI: sys.exit(1)
        end
    else --json not provided
        alt args.cmd exists
            CLI->>CLI: command = {"cmd": args.cmd}
        else args.cmd is None
            CLI->>User: Error: either CMD or --json must be provided
            CLI->>CLI: sys.exit(1)
        end
    end
    
    CLI->>QueryDaemon: query_daemon(project_path, command)
    QueryDaemon->>Daemon: Send JSON command via socket
    Daemon->>Daemon: handle_command(command)
    Daemon-->>QueryDaemon: JSON response
    QueryDaemon-->>CLI: response dict
    CLI->>User: Print JSON output
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->