### PR TITLE
Fix MPS crash on macOS by defaulting to CPU and adding --device flag

### DIFF
--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -167,12 +167,46 @@ def _confirm_download(model_key: str) -> bool:
         return False
 
 
-def get_model(model_name: Optional[str] = None):
+def _get_device() -> str:
+    """Get the device to use for model inference.
+
+    Checks TLDR_DEVICE environment variable first, then auto-detects.
+    On Apple Silicon, defaults to CPU to avoid MPS stability issues.
+
+    Returns:
+        Device string: "cpu", "cuda", or "mps"
+    """
+    # Check environment variable first
+    env_device = os.environ.get("TLDR_DEVICE", "").lower()
+    if env_device in ("cpu", "cuda", "mps"):
+        return env_device
+
+    # Check for MPS fallback mode (set by our wrapper scripts)
+    if os.environ.get("PYTORCH_ENABLE_MPS_FALLBACK") == "1":
+        return "cpu"
+
+    # Auto-detect: prefer CUDA, then CPU (skip MPS due to stability issues)
+    try:
+        import torch
+        if torch.cuda.is_available():
+            return "cuda"
+        # Note: We intentionally skip MPS even if available due to
+        # known crashes in MetalPerformanceShaders (SIGABRT in MPSKey_Compile).
+        # Users can force MPS with TLDR_DEVICE=mps if they want to try it.
+    except ImportError:
+        pass
+
+    return "cpu"
+
+
+def get_model(model_name: Optional[str] = None, device: Optional[str] = None):
     """Lazy-load the embedding model (cached).
 
     Args:
         model_name: Model key from SUPPORTED_MODELS, or None for default.
                    Can also be a full HuggingFace model name.
+        device: Device to use ("cpu", "cuda", "mps"). If None, auto-detects.
+                Can also be set via TLDR_DEVICE environment variable.
 
     Returns:
         SentenceTransformer model instance.
@@ -193,7 +227,11 @@ def get_model(model_name: Optional[str] = None):
         # Allow arbitrary HuggingFace model names
         hf_name = model_name
 
-    # Return cached model if same
+    # Resolve device
+    if device is None:
+        device = _get_device()
+
+    # Return cached model if same model and device
     if _model is not None and _model_name == hf_name:
         return _model
 
@@ -204,7 +242,19 @@ def get_model(model_name: Optional[str] = None):
             raise ValueError(f"Model download declined. Use --model to choose a smaller model.")
 
     from sentence_transformers import SentenceTransformer
-    _model = SentenceTransformer(hf_name)
+
+    logger.info(f"Loading model {hf_name} on device: {device}")
+
+    try:
+        _model = SentenceTransformer(hf_name, device=device)
+    except Exception as e:
+        # If MPS fails, fall back to CPU
+        if device == "mps":
+            logger.warning(f"MPS failed ({e}), falling back to CPU")
+            _model = SentenceTransformer(hf_name, device="cpu")
+        else:
+            raise
+
     _model_name = hf_name
     return _model
 
@@ -262,19 +312,20 @@ def build_embedding_text(unit: EmbeddingUnit) -> str:
     return "\n".join(parts)
 
 
-def compute_embedding(text: str, model_name: Optional[str] = None):
+def compute_embedding(text: str, model_name: Optional[str] = None, device: Optional[str] = None):
     """Compute embedding vector for text.
 
     Args:
         text: The text to embed.
         model_name: Model to use (from SUPPORTED_MODELS or HF name).
+        device: Device for inference ("cpu", "cuda", "mps"). If None, auto-detects.
 
     Returns:
         numpy array with L2-normalized embedding.
     """
     import numpy as np
 
-    model = get_model(model_name)
+    model = get_model(model_name, device=device)
 
     # BGE models work best with instruction prefix for queries
     # For document embedding, we use text directly
@@ -936,6 +987,7 @@ def build_semantic_index(
     model: Optional[str] = None,
     show_progress: bool = True,
     respect_ignore: bool = True,
+    device: Optional[str] = None,
 ) -> int:
     """Build and save FAISS index + metadata for a project.
 
@@ -949,6 +1001,8 @@ def build_semantic_index(
         model: Model name from SUPPORTED_MODELS or HuggingFace name.
         show_progress: Show progress spinner (default: True).
         respect_ignore: If True, respect .tldrignore patterns (default True).
+        device: Device for inference ("cpu", "cuda", "mps"). If None, auto-detects.
+                Set TLDR_DEVICE environment variable to override.
 
     Returns:
         Number of indexed units.
@@ -1033,7 +1087,7 @@ def build_semantic_index(
         ) as progress:
             task = progress.add_task("Computing embeddings...", total=num_units)
 
-            model_obj = get_model(model)
+            model_obj = get_model(model, device=device)
             all_embeddings = []
 
             for i in range(0, num_units, BATCH_SIZE):
@@ -1056,7 +1110,7 @@ def build_semantic_index(
 
             embeddings_matrix = np.vstack(all_embeddings)
     else:
-        model_obj = get_model(model)
+        model_obj = get_model(model, device=device)
         result = model_obj.encode(
             texts,
             batch_size=BATCH_SIZE,
@@ -1094,6 +1148,7 @@ def semantic_search(
     k: int = 5,
     expand_graph: bool = False,
     model: Optional[str] = None,
+    device: Optional[str] = None,
 ) -> List[dict]:
     """Search for code units semantically.
 
@@ -1104,6 +1159,7 @@ def semantic_search(
         expand_graph: If True, include callers/callees in results.
         model: Model to use for query embedding. If None, uses
                the model from the index metadata.
+        device: Device for inference ("cpu", "cuda", "mps"). If None, auto-detects.
 
     Returns:
         List of result dictionaries with name, file, line, score, etc.
@@ -1142,7 +1198,7 @@ def semantic_search(
 
     # Embed query (with instruction prefix for BGE)
     query_text = f"Represent this code search query: {query}"
-    query_embedding = compute_embedding(query_text, model_name=model)
+    query_embedding = compute_embedding(query_text, model_name=model, device=device)
     query_embedding = query_embedding.reshape(1, -1)
 
     # Search

--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -215,7 +215,7 @@ def get_model(model_name: Optional[str] = None, device: Optional[str] = None):
     Raises:
         ValueError: If model not found or user declines download.
     """
-    global _model, _model_name
+    global _model, _model_name, _model_device
 
     # Resolve model name
     if model_name is None:
@@ -227,8 +227,6 @@ def get_model(model_name: Optional[str] = None, device: Optional[str] = None):
     else:
         # Allow arbitrary HuggingFace model names
         hf_name = model_name
-
-    global _model, _model_name, _model_device
 
     # Resolve device
     if device is None:
@@ -1075,8 +1073,6 @@ def build_semantic_index(
 
     if not units:
         return 0
-
-    import numpy as np
 
     BATCH_SIZE = 64
     num_units = len(units)


### PR DESCRIPTION
## Summary

Fixes #43 - Semantic index crashes on macOS with PyTorch MPS backend (SIGABRT)

On Apple Silicon Macs, PyTorch's MPS (Metal Performance Shaders) backend can crash with SIGABRT during semantic indexing due to issues in Apple's MetalPerformanceShaders library (`MPSLibrary::MPSKey_Compile`).

## Changes

- Add `_get_device()` helper that auto-detects device, defaulting to CPU (skipping MPS due to stability issues)
- Add `--device` flag to `tldr semantic index` and `tldr semantic search` commands
- Add `TLDR_DEVICE` environment variable for global device override
- Add graceful fallback to CPU if MPS fails during model loading
- Update `get_model()`, `compute_embedding()`, `build_semantic_index()`, and `semantic_search()` to accept device parameter

## Usage

```bash
# Default: uses CPU (safe, stable)
tldr semantic index .

# Force specific device
tldr semantic index . --device cuda  # NVIDIA GPU
tldr semantic index . --device mps   # Apple MPS (may crash)
tldr semantic index . --device cpu   # CPU only

# Environment variable (affects all commands)
export TLDR_DEVICE=cpu
tldr semantic index .
```

## Behavior

1. If `TLDR_DEVICE` env var is set, uses that device
2. If `PYTORCH_ENABLE_MPS_FALLBACK=1` is set, uses CPU
3. Otherwise auto-detects: prefers CUDA if available, then CPU
4. MPS is intentionally skipped in auto-detection due to stability issues
5. If MPS is explicitly requested and fails, gracefully falls back to CPU

## Test plan

- [ ] Test on macOS with Apple Silicon - should no longer crash
- [ ] Test `--device cpu` flag works
- [ ] Test `TLDR_DEVICE=cpu` environment variable works
- [ ] Test CUDA still works if available
- [ ] Test MPS can be forced with `--device mps` if user wants to try it

**Disclaimer:** This PR was created by Claude Code (Opus 4.5) while troubleshooting llm-tldr integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--device` option to semantic indexing and search so you can choose CPU, CUDA, or MPS for model inference.
  * Device selection now applies end-to-end for embeddings, indexing, and query search.

* **Bug Fixes**
  * More robust handling and fallback when loading models on MPS devices to avoid failures.

* **Documentation**
  * Updated help text to document device selection and default behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses macOS MPS crashes by adding device selection capabilities and defaulting to CPU for stability. The implementation adds a `_get_device()` helper function that auto-detects the appropriate device (preferring CUDA, then CPU, intentionally skipping MPS), along with `--device` CLI flags and `TLDR_DEVICE` environment variable support.

**Key Changes:**
- Added `_get_device()` helper in `tldr/semantic.py:170-199` that checks `TLDR_DEVICE` env var, `PYTORCH_ENABLE_MPS_FALLBACK`, then auto-detects (CUDA > CPU, skipping MPS)
- Modified `get_model()` to accept device parameter with MPS fallback to CPU on failure (lines 248-256)
- Added device parameter to `compute_embedding()`, `build_semantic_index()`, and `semantic_search()` functions
- Added `--device` flag to `tldr semantic index` and `tldr semantic search` commands in CLI
- Updated help text explaining device selection behavior

**Critical Issue:**
- Model caching in `get_model()` at line 235 doesn't track device - will return cached model even if different device is requested, breaking device switching functionality

**Missing Requirements:**
- No tests added despite repository owner requirement: "Please ensure all PRs have tests to prove fixes"
- Should include tests for: device auto-detection, `TLDR_DEVICE` env var, MPS fallback behavior, and device switching

<h3>Confidence Score: 2/5</h3>

- This PR has a critical caching bug that will break device switching and lacks required tests
- Score of 2 reflects a critical logical error in the model caching mechanism (tldr/semantic.py:234-236) that will cause the wrong device model to be used when device changes between calls. Additionally, the PR violates repository policy by not including any tests to verify the fix works, despite the owner's explicit requirement. The core implementation approach is sound (device auto-detection, MPS fallback), but the caching bug makes it unsafe to merge without fixes.
- Pay close attention to `tldr/semantic.py` - the model caching logic needs to track device to prevent returning cached models for the wrong device

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tldr/semantic.py | Added device selection with `_get_device()` helper and device parameter to model loading functions. Critical bug: model cache doesn't track device, will return wrong device model. |
| tldr/cli.py | Added `--device` flag to semantic index and search commands with proper help text and device choices. Device parameter correctly passed through to semantic functions. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as tldr/cli.py
    participant Semantic as tldr/semantic.py
    participant PyTorch
    participant SentenceTransformer

    User->>CLI: tldr semantic index . --device cpu
    CLI->>Semantic: build_semantic_index(path, device="cpu")
    Semantic->>Semantic: _get_device() -> "cpu"
    Note over Semantic: Checks TLDR_DEVICE env var<br/>then PYTORCH_ENABLE_MPS_FALLBACK<br/>then auto-detects (CUDA > CPU)
    Semantic->>Semantic: get_model(device="cpu")
    Semantic->>Semantic: Check cache (_model != None?)
    alt Model not cached or different device
        Semantic->>SentenceTransformer: SentenceTransformer(model, device="cpu")
        alt Device is MPS and fails
            SentenceTransformer-->>Semantic: Exception
            Semantic->>SentenceTransformer: Fallback to SentenceTransformer(model, device="cpu")
        end
        SentenceTransformer-->>Semantic: model instance
        Semantic->>Semantic: Cache model in _model, _model_name
    end
    Semantic->>Semantic: compute_embedding(text, device)
    Semantic->>SentenceTransformer: model.encode(texts)
    SentenceTransformer-->>Semantic: embeddings
    Semantic-->>CLI: indexed count
    CLI-->>User: "Indexed N code units"
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->