### PR TITLE
Feat/isolated index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `tldr/`: core library and CLI implementation (daemon, indexing, semantic search, analysis layers).
+- `tests/`: pytest suite (`test_*.py`).
+- `docs/`, `implementations/`, `specs/`: product docs, implementation plans, and feature specs.
+- `scripts/`: helper utilities for local workflows.
+
+## Build, Test, and Development Commands
+- `uv venv && uv pip install -e ".[dev]"`: create a virtualenv and install dev dependencies.
+- `uv run pytest`: run the full test suite (preferred; ensures all deps are available).
+- `uv run pytest tests/test_some_area.py`: run a focused test file.
+- `uv run ruff check tldr/`: lint the codebase.
+
+## Coding Style & Naming Conventions
+- Python code uses 4-space indentation and `snake_case` for functions/variables.
+- Keep module names short and lowercase (e.g., `tldr/daemon/identity.py`).
+- Favor explicit types and small, composable functions.
+- Use `ruff` for linting; fix warnings before PRs.
+
+## Testing Guidelines
+- Framework: `pytest`.
+- Test files live in `tests/` and follow `test_*.py` naming.
+- Run tests with `uv run pytest` to avoid missing dependency issues.
+- Add/adjust tests when changing behavior in CLI, daemon, or indexing paths.
+
+## Commit & Pull Request Guidelines
+- Commit messages follow Conventional Commits. Examples: `feat: add index-aware daemon identity`, `fix: handle ignore file mismatch`, `docs: update CLI examples`.
+- Keep PRs focused on one logical change.
+- Before opening a PR, rebase on `main`, run `uv run pytest` and `uv run ruff check tldr/`, and update docs when public behavior changes.
+
+## Configuration & Runtime Notes
+- The CLI honors `TLDR_*` env vars (e.g., `TLDR_CACHE_ROOT`, `TLDR_INDEX`, `TLDR_SCAN_ROOT`).
+- Prefer `uv run …` for any command that depends on optional native or ML deps.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## Build, Test, and Development Commands
 - `uv venv && uv pip install -e ".[dev]"`: create a virtualenv and install dev dependencies.
-- `uv run pytest`: run the full test suite (preferred; ensures all deps are available).
+- `uv run pytest`: run the full test suite (preferred; ensures all deps are available). DO NOT USE pip or "python -m pytest"
 - `uv run pytest tests/test_some_area.py`: run a focused test file.
 - `uv run ruff check tldr/`: lint the codebase.
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,27 @@ tldr semantic "error handling"  # Find by behavior
 
 ---
 
+## Agent Skills (Included)
+
+This repo includes a dependency-indexing skill at `skills/llm-tldr-dep-indexer/`.
+
+It supports:
+- Python dependencies from `.venv` / `site-packages`
+- Node dependencies from `node_modules`
+
+What it lets an agent do:
+- Resolve the exact installed dependency source + version
+- Create or reuse a **versioned, isolated** index for that dependency
+- Keep caches under the repo root via `--cache-root=git`
+- Query the dependency directly without mixing it with the main repo
+
+Quick example (Python):
+```bash
+python skills/llm-tldr-dep-indexer/scripts/ensure_dep_index.py python requests
+```
+
+---
+
 ## Real Example: Why This Matters
 
 **Scenario:** Debug why `user` is null on line 42.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,23 @@ python skills/llm-tldr-dep-indexer/scripts/ensure_dep_index.py python requests
 
 ---
 
+This repo also includes a usage skill at `skills/llm-tldr-usage/`.
+
+It supports:
+- Indexing and querying repos with `tldr warm`, `tldr semantic`, `tldr context`, `tldr slice`, and `tldr impact`
+- Isolated indexes with `--cache-root=git` and `--index`
+- Index management via `tldr index list/info/rm`
+- Daemon workflows and `.tldrignore` usage
+
+Quick example:
+```bash
+tldr warm --cache-root=git .
+tldr semantic index --cache-root=git .
+tldr semantic search "token validation flow" --cache-root=git --path .
+```
+
+---
+
 ## Real Example: Why This Matters
 
 **Scenario:** Debug why `user` is null on line 42.

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -1,0 +1,105 @@
+# Benchmarks
+
+## Summary
+
+These benchmarks validate that the isolated index feature preserves search quality while enabling dependency-scoped search and clean cache management.
+
+Results date: 2026-02-03
+
+## How To Run
+
+```bash
+uv run python scripts/bench_dep_indexes.py
+```
+
+Common flags:
+```bash
+uv run python scripts/bench_dep_indexes.py --dep requests --model all-MiniLM-L6-v2 --device cpu --k 5 --queries scripts/bench_queries.json
+```
+
+## Environment
+
+- Repo: `llm-tldr`
+- Dependency corpus: `requests` from `.venv`
+  - Source path: `.venv/lib/python3.12/site-packages/requests`
+- Main repo scan root: `tldr/`
+- Model: `all-MiniLM-L6-v2`
+- Device: `cpu`
+- `--no-ignore` used for all runs
+
+## Benchmark Results
+
+### Benchmark 1: Parity (same corpus)
+
+Goal: show that legacy indexing and index-mode indexing produce the same search quality for the same corpus.
+
+Legacy index (writes `.tldr` inside the corpus):
+- Indexed units: 276
+- Index time: 8.27s
+- Disk usage: ~608 KB
+- Recall@5: 1.0
+- MRR: 1.0
+- Avg time-to-first-relevant-hit: 3.94s
+
+Index mode (`--cache-root` + `--index`):
+- Indexed units: 276
+- Index time: 8.43s
+- Disk usage: ~611 KB
+- Recall@5: 1.0
+- MRR: 1.0
+- Avg time-to-first-relevant-hit: 3.93s
+
+Conclusion: search quality is equivalent. The change is storage/management, not ranking.
+
+### Benchmark 2: Workflow (dependency debugging)
+
+Goal: show why per-dependency indexes matter.
+
+Baseline (search only main repo index):
+- Recall@5: 0.0
+- MRR: 0.0
+- No relevant hits for dependency queries
+
+Dependency index (search the dependency directly):
+- Recall@5: 1.0
+- MRR: 1.0
+- Avg time-to-first-relevant-hit: 3.93s
+
+Conclusion: dependency queries are missed if you only index the main repo. Per-dependency indexes fix that.
+
+### Benchmark 3: Storage + Time
+
+Index sizes (from `tldr index list --cache-root ...`):
+- `main:llm-tldr`: ~2.53 MB
+- `dep:requests`: ~0.61 MB
+- Total cache root size: ~3.14 MB
+
+Conclusion: per-dependency indexes are small and cheap to keep around.
+
+## Why The New Feature Enables This
+
+Isolated indexes were added via two CLI flags:
+- `--cache-root`: base directory where all index data is stored.
+- `--index`: logical index id that namespaces caches under the cache root.
+
+This allows multiple independent indexes under a single cache root (one per repo or dependency) without writing `.tldr` inside each dependency folder. As a result:
+- You can index multiple dependencies separately.
+- You can query each dependency directly without “pollution” from other corpora.
+- You can list, inspect, and remove indexes cleanly using `tldr index list/info/rm`.
+
+## Where The Cache Is Stored
+
+Legacy mode (no `--cache-root`):
+- Cache lives inside the corpus: `<scan_root>/.tldr/cache/...`
+
+Index mode (with `--cache-root` + `--index`):
+- Cache lives under the cache root, namespaced by a stable hash of the index id:
+  - `<cache_root>/.tldr/indexes/<index_key>/cache/...`
+  - `<cache_root>/.tldr/indexes/<index_key>/meta.json`
+  - `<cache_root>/.tldr/indexes/<index_key>/.tldrignore`
+
+`<index_key>` is derived from the `--index` value, and `meta.json` stores the index id and scan root so `tldr index list/info` can display it.
+
+## Notes
+
+Semantic search returns file paths relative to the scan root. When indexing a package directory directly, results may look like `sessions.py` rather than `requests/sessions.py`. The benchmark evaluator accepts either a basename match or a substring match.

--- a/implementations/001-feat-isolated-index.md
+++ b/implementations/001-feat-isolated-index.md
@@ -12,6 +12,13 @@ Add a first-class **Index** concept so TLDR can:
 - Support multi-index operation in the **daemon** and **MCP server**
 - Provide **index management** commands (`list/info/rm/gc`)
 
+## Phases (suggested delivery)
+
+- Phase 1 (MVP: isolated index + semantic): CLI flag plumbing + per-index cache layout + semantic isolation + “no writes outside cache_root” guard + baseline tests.
+- Phase 2 (Ignore + completeness): index-scoped ignore file + gitignore toggles + ensure every subcommand uses `IndexContext` consistently.
+- Phase 3 (Daemon + MCP): per-index daemon identity + request routing + daemon isolation tests.
+- Phase 4 (Index management): `tldr index list/info/rm/gc` (+ optional `gc`) + cleanup/UX polish.
+
 ## Goals (Acceptance Criteria)
 
 1. CLI supports `--scan-root`, `--cache-root`, `--index` and uses them consistently across:
@@ -343,14 +350,6 @@ Ignore knobs (`--ignore-file`, `--use-gitignore/--no-gitignore`) must work in **
 
 Pros: no migration complexity; no test churn for existing expectations.
 Cons: two layouts to support long-term.
-
-### Option B: Always use new layout (with migration)
-
-- Treat current state as `index_id="default"`, store in `indexes/<key-of-default>/`.
-- On first run, migrate existing `.tldr/cache/*` into the default index dir (or keep reading old paths as fallback).
-
-Pros: one layout going forward.
-Cons: migration risk; requires updating multiple tests/docs in one go.
 
 ## Ignore Handling (Index-Scoped)
 

--- a/implementations/001-feat-isolated-index.md
+++ b/implementations/001-feat-isolated-index.md
@@ -20,11 +20,19 @@ Add a first-class **Index** concept so TLDR can:
 - [x] Update MCP server to accept index flags, enforce fixed index routing, and pass flags to daemon auto-start.
 - [x] Add daemon identity isolation tests.
 - [x] Run targeted tests: `pytest tests/test_daemon_identity.py`
+- [x] Add index management helpers for list/info/rm/gc, including daemon-running safety checks and port file cleanup.
+- [x] Wire `tldr index` CLI subcommands with cache-root validation and JSON output.
+- [x] Add index management tests (list/info/rm/gc + daemon-running guard).
+- [x] Run full test suite: `uv run pytest`.
+- [x] Run lint: `uv run ruff check tldr/`.
 
 ## Gotchas / Learnings (rolling)
 
 - MCP tool defaults pass `project="."`; when MCP is started with a fixed index, treat `"."` as “unset” to avoid false mismatches.
 - Windows daemon port collisions are now mitigated by persisting the selected port in a temp file keyed by the daemon identity.
+- Index GC uses `meta.last_used_at` when present; otherwise it falls back to `meta.json`/index dir mtime for age decisions.
+- Exposed a small `is_daemon_alive()` wrapper to reuse daemon liveness checks in index management without duplicating lock logic.
+- Ruff surfaced a set of pre-existing unused imports/vars; cleaned these as part of Phase 4 to get `ruff check` green.
 
 ## Phases (suggested delivery)
 

--- a/implementations/001-feat-isolated-index.md
+++ b/implementations/001-feat-isolated-index.md
@@ -12,6 +12,20 @@ Add a first-class **Index** concept so TLDR can:
 - Support multi-index operation in the **daemon** and **MCP server**
 - Provide **index management** commands (`list/info/rm/gc`)
 
+## Immediate Next Steps (rolling)
+
+- [x] Add daemon identity helpers (index-aware socket/lock/pid/port) + extend `IndexPaths` for daemon-related files.
+- [x] Refactor daemon core/startup to accept `IndexContext`, use index paths/config roots, and propagate index flags in background reindex + Windows spawn.
+- [x] Update CLI daemon commands to pass index context and preserve index identity.
+- [x] Update MCP server to accept index flags, enforce fixed index routing, and pass flags to daemon auto-start.
+- [x] Add daemon identity isolation tests.
+- [x] Run targeted tests: `pytest tests/test_daemon_identity.py`
+
+## Gotchas / Learnings (rolling)
+
+- MCP tool defaults pass `project="."`; when MCP is started with a fixed index, treat `"."` as “unset” to avoid false mismatches.
+- Windows daemon port collisions are now mitigated by persisting the selected port in a temp file keyed by the daemon identity.
+
 ## Phases (suggested delivery)
 
 - Phase 1 (MVP: isolated index + semantic): CLI flag plumbing + per-index cache layout + semantic isolation + “no writes outside cache_root” guard + baseline tests.

--- a/implementations/001-feat-isolated-index.md
+++ b/implementations/001-feat-isolated-index.md
@@ -1,0 +1,348 @@
+# Implementation Plan: 001 - Isolated Indexes
+
+Spec: `specs/001-feat-isolated-index.md`
+
+## Summary
+
+Add a first-class **Index** concept so TLDR can:
+
+- **Scan code in-place** (e.g. `node_modules/pkg`, `.venv/.../site-packages/pkg`)
+- **Store all TLDR state under a chosen cache root** (e.g. your repo root)
+- **Maintain multiple isolated indexes** (one per `module@version`), preventing cache collisions across deps
+- Support multi-index operation in the **daemon** and **MCP server**
+- Provide **index management** commands (`list/info/rm/gc`)
+
+## Goals (Acceptance Criteria)
+
+1. CLI supports `--scan-root`, `--cache-root`, `--index` and uses them consistently across:
+   - `warm`, `semantic index/search`, `tree`, `structure`, `search`, `context`, `calls`, `impact`, `imports`, `importers`, daemon commands.
+2. All caches are **namespaced per index** under `cache_root/.tldr/indexes/<index_key>/...`.
+3. Semantic indexing:
+   - Never “walks upward” to find the project root when explicit `--cache-root/--index` are provided.
+   - Reads/writes FAISS + metadata only under the selected index directory.
+   - Stores the embedding model in index metadata and rejects mismatches (or forces explicit override).
+4. Ignore config is **index-scoped**:
+   - Default ignore file at `cache_root/.tldr/indexes/<index_key>/.tldrignore`.
+   - Add `--ignore-file`, and `--use-gitignore/--no-gitignore`.
+5. Daemon/MCP:
+   - Daemon socket/lock/pid identity is keyed by `(cache_root, index_id)` (one daemon per index).
+   - Daemon always uses the correct scan_root + index caches.
+6. Index management commands exist and are safe:
+   - `tldr index list --cache-root ...`
+   - `tldr index info <index_id> --cache-root ...`
+   - `tldr index rm <index_id> --cache-root ...`
+   - `tldr index gc --cache-root ...` (optional)
+7. Tests cover:
+   - Path resolution and collision avoidance across two indexes
+   - Two indexes under one repo root don’t overwrite each other
+   - Daemon queries for index A never read caches for index B
+
+## Non-Goals (for this spec)
+
+- Automatically resolving `module@version` for every ecosystem (leave to the “dep-tldr” skill / a future “auto id” helper).
+- Multi-index queries (search across several indexes at once). The spec target is “one daemon per index”.
+- Copying dependencies into a separate analysis directory (explicitly avoided).
+
+## Proposed User-Facing CLI
+
+### Global flags / env vars
+
+Add to top-level parser (applies to all subcommands):
+
+- `--scan-root <path>` (env `TLDR_SCAN_ROOT`)
+- `--cache-root <path>` (env `TLDR_CACHE_ROOT`)
+- `--index <id>` (env `TLDR_INDEX`)
+- `--ignore-file <path>` (env `TLDR_IGNORE_FILE`)
+- `--use-gitignore` / `--no-gitignore` (env `TLDR_USE_GITIGNORE=1|0`)
+
+Precedence (highest → lowest):
+
+1. CLI flags
+2. env vars
+3. legacy defaults (current behavior)
+
+### Path semantics (positional vs `--scan-root`)
+
+- For subcommands with a positional directory `path` argument (e.g. `warm/tree/structure/search`), treat that positional value as the default `scan_root`.
+- `--scan-root` overrides the positional directory path.
+- If both are provided and resolve to different paths, exit with an error (avoid silently indexing the wrong tree).
+- For existing command-specific flags that represent a scan root (e.g. `context --project`, `semantic search --path`), keep them as aliases for `scan_root` for backward compatibility, but prefer documenting `--scan-root`.
+
+### Examples
+
+Index a Node dep **in-place**, store caches under repo root:
+
+```bash
+tldr warm --cache-root . --scan-root node_modules/zod --index node:zod@3.23.8 --no-gitignore
+tldr semantic index --cache-root . --scan-root node_modules/zod --index node:zod@3.23.8 --lang typescript
+tldr semantic search "parse schema errors" --cache-root . --scan-root node_modules/zod --index node:zod@3.23.8
+```
+
+Index a Python dep in `.venv`:
+
+```bash
+tldr warm --cache-root . --scan-root .venv/lib/python3.12/site-packages/requests --index py:requests@2.31.0 --no-gitignore
+```
+
+Default behavior (no flags): unchanged.
+
+## Index Model
+
+### Data structures (new)
+
+Add a small module to centralize index concerns, e.g. `tldr/indexing/index.py`:
+
+- `IndexConfig` (dataclass):
+  - `cache_root: Path`
+  - `scan_root: Path`
+  - `index_id: str` (logical id; may contain `:`, `@`, `/`, etc.)
+  - `index_key: str` (filesystem-safe key derived from `index_id`)
+  - `languages: list[str] | None`
+  - `semantic_model: str | None`
+  - `ignore_file: Path`
+  - `use_gitignore: bool`
+  - `created_at/updated_at` (optional)
+
+- `IndexPaths` helper:
+  - `index_dir = cache_root/.tldr/indexes/<index_key>/`
+  - `meta = index_dir/meta.json`
+  - `call_graph = index_dir/call_graph.json`
+  - `languages = index_dir/languages.json`
+  - `dirty = index_dir/dirty.json` (replace `.tldr/cache/dirty.json` in index-mode)
+  - `semantic_dir = index_dir/semantic/`
+  - `semantic_faiss = semantic_dir/index.faiss`
+  - `semantic_metadata = semantic_dir/metadata.json`
+
+### Index ID vs on-disk key
+
+To stay cross-platform, introduce a filesystem-safe `index_key`:
+
+- Keep `index_id` as the stable external identifier shown to users and stored in `meta.json`.
+- Derive `index_key` via a deterministic encoding (recommended):
+  - `index_key = base32(sha256(index_id))[:16] + "-" + slug(index_id)[:48]`
+  - Store both fields in `meta.json` so list/info can map back.
+
+Rationale: `:` and `/` are invalid on Windows; raw `index_id` cannot safely be used as a directory name.
+
+## Cache Layout (New)
+
+Under `cache_root`:
+
+```
+.tldr/
+  indexes/
+    <index_key>/
+      meta.json
+      call_graph.json
+      languages.json
+      dirty.json
+      .tldrignore
+      semantic/
+        index.faiss
+        metadata.json
+```
+
+Keep existing single-index layout for legacy mode (no flags), at minimum:
+
+```
+.tldr/cache/call_graph.json
+.tldr/languages.json
+.tldr/cache/semantic/{index.faiss,metadata.json}
+.tldr/cache/dirty.json
+```
+
+## Backward Compatibility Strategy
+
+Two viable approaches; pick one early and keep it consistent:
+
+### Option A (recommended): “Legacy mode” stays untouched
+
+- If the user does not provide any of the index-related knobs (`--cache-root`, `--scan-root`, `--index`, `--ignore-file`, `--use-gitignore/--no-gitignore`, or env equivalents), keep current paths and behavior exactly.
+- If **any** of those are provided, switch into “index mode” and use the new `indexes/<index_key>/...` layout.
+- If in index mode and `--index` is omitted, auto-derive a deterministic `index_id` from `scan_root`:
+  - Prefer `path:<scan_root relative to cache_root>` when `scan_root` is under `cache_root`.
+  - Otherwise use `abs:<scan_root resolved>`.
+
+Pros: no migration complexity; no test churn for existing expectations.
+Cons: two layouts to support long-term.
+
+### Option B: Always use new layout (with migration)
+
+- Treat current state as `index_id="default"`, store in `indexes/<key-of-default>/`.
+- On first run, migrate existing `.tldr/cache/*` into the default index dir (or keep reading old paths as fallback).
+
+Pros: one layout going forward.
+Cons: migration risk; requires updating multiple tests/docs in one go.
+
+## Ignore Handling (Index-Scoped)
+
+### Implementation changes
+
+Update `tldr/tldrignore.py` to support:
+
+- Loading patterns from an arbitrary ignore file path (not necessarily `scan_root/.tldrignore`).
+- Allow specifying a separate `gitignore_root` (recommended: `cache_root` in index mode).
+
+Suggested interface:
+
+- `load_ignore_patterns_from_file(ignore_file: Path) -> PathSpec`
+- `ensure_ignore_file(ignore_file: Path) -> (created: bool, msg: str)`
+- `IgnoreSpec(scan_root: Path, ignore_file: Path, use_gitignore: bool, gitignore_root: Path, cli_patterns: list[str] | None)`
+  - `match_file(rel_path)` uses patterns relative to `scan_root`.
+  - gitignore checks use `gitignore_root` with relpaths relative to that root.
+
+Default in index mode:
+
+- `ignore_file = index_dir/.tldrignore` (create if missing using existing DEFAULT_TEMPLATE)
+- `use_gitignore = False` if `scan_root` looks like a dependency dir (`node_modules`, `.venv`, `site-packages`) OR if user passes `--no-gitignore`
+- `gitignore_root = cache_root` if `use_gitignore=True`
+
+## Semantic Indexing Changes
+
+### Current issue
+
+`tldr/semantic.py` uses `_find_project_root(scan_path)` and writes to:
+
+- `<project_root>/.tldr/cache/semantic/...`
+
+This collides across multiple scan roots inside the same repo.
+
+### Plan
+
+1. Add optional `IndexConfig`/`IndexPaths` parameters to:
+   - `build_semantic_index(...)`
+   - `semantic_search(...)`
+2. If `cache_root/index` are provided:
+   - Do not call `_find_project_root()`.
+   - Read/write strictly within `index_paths.semantic_dir`.
+3. Persist model info:
+   - `meta.json` stores the selected embedding model (HF name) and dimension.
+   - `semantic/metadata.json` also stores model + dimension; enforce consistency.
+4. Model mismatch policy:
+   - **Search:** if the user supplies `--model` and it does not match the model recorded in `semantic/metadata.json`, error (results would be invalid and FAISS dimensions may not match). If `--model` is omitted, always use the model recorded in metadata.
+   - **Index build:** if an index already exists and the requested `--model` differs, require an explicit overwrite flag (recommend `--rebuild`) to overwrite.
+   - Always validate embedding **dimension** (from metadata vs FAISS index) before querying.
+
+## Call Graph + “Warm” Cache Namespacing
+
+### Current issue
+
+Call graph cache and language cache are written under `<scan_root>/.tldr/...` and collide.
+
+### Plan
+
+1. Centralize call graph cache IO behind `IndexPaths`:
+   - read/write `call_graph.json`, `languages.json`, `dirty.json` (index-mode)
+2. Modify:
+   - `tldr/cli.py`:
+     - `_get_or_build_graph()` uses `index_paths.call_graph`.
+     - `warm` writes `index_paths.call_graph` and `index_paths.languages`.
+     - `resolve_language()` reads `index_paths.languages`.
+   - `tldr/session_warm.py`: use `IndexPaths` for cache age checks.
+   - `tldr/dirty_flag.py`: make dirty file path configurable; in index-mode store under index dir.
+
+## Daemon + MCP Multi-Index Support
+
+### Identity / socket naming
+
+Update `tldr/daemon/startup.py` and `tldr/daemon/core.py`:
+
+- Replace “hash(project_path)” with “hash(cache_root + index_id)”.
+- Keep tmp files:
+  - `/tmp/tldr-<hash>.sock`
+  - `/tmp/tldr-<hash>.pid`
+  - `/tmp/tldr-<hash>.lock`
+
+### Daemon config
+
+Update TLDRDaemon to be created with `IndexConfig`:
+
+- `cache_root` determines where `.tldr/indexes/...` lives
+- `scan_root` determines what the daemon scans/serves
+- All query handlers use:
+  - `scan_root` for filesystem scans and relative paths
+  - `index_paths.*` for caches
+
+### CLI surface
+
+Update `tldr cli daemon {start,stop,status,query,notify}` to accept global index flags and propagate them to daemon startup/query.
+
+### MCP server
+
+Update `tldr/mcp_server.py`:
+
+- Accept `--cache-root`, `--scan-root`, `--index` flags (and env vars).
+- Compute socket identity from `(cache_root, index_id)`.
+- When auto-starting the daemon, pass the same index flags through to `tldr cli daemon start ...`.
+
+## Index Management Commands
+
+Add `tldr index` subcommand tree in `tldr/cli.py`:
+
+- `tldr index list --cache-root <path>`
+  - List all `indexes/*/meta.json` entries (display `index_id`, `scan_root`, size, last_updated)
+- `tldr index info <index_id> --cache-root <path>`
+  - Resolve `index_id` to `index_key` by scanning meta files
+  - Print meta + cache file presence and sizes
+- `tldr index rm <index_id> --cache-root <path> [--force]`
+  - Deletes that index directory only
+  - Refuses to remove unknown/unparseable dirs unless `--force`
+- `tldr index gc --cache-root <path> [--days N] [--max-total-mb M]` (optional)
+  - Removes indexes not used recently (based on `meta.json` timestamps)
+
+## Testing Plan
+
+### Unit tests
+
+1. `tests/test_index_paths.py`
+   - `IndexPaths` resolves distinct directories for two different `index_id`s under the same `cache_root`
+   - `index_key` sanitization is deterministic and collision-resistant
+
+2. `tests/test_ignore_index_scoped.py`
+   - Using `--ignore-file` affects filtering even when `scan_root` is elsewhere
+
+### Integration tests (no daemon)
+
+`tests/test_isolated_indexes_integration.py`:
+
+- Create a tmp “repo” directory as `cache_root`
+- Create two “deps” as separate scan roots with distinct code
+- Run:
+  - `build_semantic_index(scan_root=A, cache_root=repo, index=A)`
+  - `build_semantic_index(scan_root=B, cache_root=repo, index=B)`
+- Assert:
+  - `repo/.tldr/indexes/<A>/semantic/...` and `<B>/semantic/...` both exist
+  - `semantic_search(..., index=A)` never opens B’s FAISS
+  - Results differ by content (each dep has a uniquely-named function)
+
+### Integration tests (daemon)
+
+`tests/test_daemon_isolated_indexes.py` (run on Unix and Windows if feasible):
+
+- Start daemon for index A, query `tree/structure/search` and verify it matches scan_root A
+- Start daemon for index B and verify it matches scan_root B
+- Ensure sockets differ (hash differs) and stop both cleanly
+
+## Implementation Sequence (Phased)
+
+1. **Index core**
+   - Add `IndexConfig` + `IndexPaths` + meta read/write helpers
+2. **CLI plumbing**
+   - Add global flags/env resolution
+   - Thread `IndexConfig` into relevant CLI handlers
+3. **Cache namespacing**
+   - Call graph + languages + dirty + semantic cache paths via `IndexPaths`
+4. **Ignore refactor**
+   - Index-scoped ignore file creation + gitignore toggle
+5. **Daemon/MCP**
+   - Daemon keyed by `(cache_root,index_id)` and uses correct scan_root
+6. **Index commands**
+   - list/info/rm/gc
+7. **Tests + docs**
+   - Add new tests; update docs/README with examples and cache layout
+
+## Design Decisions (Recommended)
+
+1. **Positional path stays** for backward compatibility and convenience, and is treated as the default `scan_root`. `--scan-root` overrides it; specifying both with different resolved paths is an error.
+2. **Index mode activates** when **any** of the new knobs is set (CLI or env). If `--index` is omitted in index mode, derive a deterministic `index_id` from `scan_root` (prefer `path:` relative to `cache_root`, otherwise `abs:`).
+3. **Semantic model mismatch is a hard error** when searching with an explicit `--model` that differs from metadata; rebuilding with a different model requires an explicit overwrite flag (recommend `--rebuild`).

--- a/implementations/002-benchmark-isolated-index.md
+++ b/implementations/002-benchmark-isolated-index.md
@@ -1,0 +1,146 @@
+# Implementation Plan: 002 - Benchmark Isolated Indexes
+
+Spec: N/A (benchmarks and validation plan)
+
+## Summary
+
+Short answer: yes, but benchmark the right dimension. The new implementation doesn’t change the search model; it changes index isolation, cache location, and management. So you need both a parity benchmark (same corpus, same results) and a workflow benchmark (dependency discovery and isolation).
+
+## What Changed (Scope of Comparison)
+
+- It enables multiple isolated indexes under one cache root.
+- It avoids writing `.tldr` inside dependency folders like `site-packages` or `node_modules`.
+- It makes dependency indexing manageable and repeatable via `tldr index list/info/rm`.
+
+Apples-to-apples means: compare the same corpus indexed both ways.
+
+## Benchmarks
+
+### Benchmark 1: Parity (same corpus, same answers)
+
+Goal: prove index mode does not change search quality for a given corpus.
+
+1. Pick a dependency repo (or sdist extraction) as the corpus.
+2. Build an index using old behavior (inside repo, no `--cache-root`).
+3. Build an index using new index mode (`--cache-root` + `--index`).
+4. Run the same query list and compare results (Recall@k, MRR, top hit path match).
+
+If results match, the new path is functionally equivalent, and differences are only in storage/management.
+
+### Benchmark 2: Workflow Benefit (dependency debugging)
+
+Goal: show new capability that the old workflow can’t do cleanly.
+
+1. Create a query set that targets dependency behavior.
+2. Baseline: search only the main repo index.
+3. New workflow: search the dependency index directly.
+4. Measure recall@k, time-to-first-relevant-hit, and number of commands.
+
+This shows why per-dependency indexes actually improve debugging tasks.
+
+### Benchmark 3: Storage + Time
+
+Goal: quantify overhead.
+
+- Index time (per corpus).
+- Disk usage of index artifacts.
+- Total number of indexes and their sizes (`tldr index list --cache-root ...`).
+
+## Practical Query Set (objective metrics)
+
+Create a small JSON list like:
+
+```json
+[
+  {
+    "dep": "requests",
+    "query": "Session.request implementation",
+    "expect_path_contains": "requests/sessions.py"
+  },
+  {
+    "dep": "pydantic",
+    "query": "BaseModel.model_validate",
+    "expect_path_contains": "pydantic/main.py"
+  }
+]
+```
+
+Run the same list across both setups and score “hit in top-k”.
+
+## What This Answers
+
+- The “standard way” (index the main repo only) will miss dependencies.
+- The new way doesn’t improve the model, but it enables dependency-scoped indexes so you can find answers in the right codebase without pollution.
+
+## Optional Automation
+
+If needed, add a small `scripts/bench_dep_indexes.py` to automate parity + workflow benchmarks and output Recall@k, MRR, time-to-first-hit, and timings.
+
+## Implementation
+
+Added:
+- `scripts/bench_dep_indexes.py` (runs parity + workflow + storage/time benchmarks)
+- `scripts/bench_queries.json` (query set)
+
+Run:
+```bash
+uv run python scripts/bench_dep_indexes.py
+```
+
+Optional flags:
+- `--dep <import-name>` (default: `requests`)
+- `--model all-MiniLM-L6-v2`
+- `--device cpu`
+- `--k 5`
+- `--queries scripts/bench_queries.json`
+
+## Results (2026-02-03)
+
+Environment:
+- Repo: `llm-tldr`
+- Dependency corpus: `requests` from `.venv`
+- Main repo scan root: `tldr/`
+- Model: `all-MiniLM-L6-v2`
+- Device: `cpu`
+- `--no-ignore` for all runs
+
+### Benchmark 1: Parity (same corpus)
+
+Legacy index (writes `.tldr` in corpus):
+- Indexed units: 276
+- Index time: 8.27s
+- Disk usage: ~608 KB
+- Recall@5: 1.0
+- MRR: 1.0
+- Avg time-to-first-relevant-hit: 3.94s
+
+Index mode (`--cache-root` + `--index`):
+- Indexed units: 276
+- Index time: 8.43s
+- Disk usage: ~611 KB
+- Recall@5: 1.0
+- MRR: 1.0
+- Avg time-to-first-relevant-hit: 3.93s
+
+### Benchmark 2: Workflow (dependency debugging)
+
+Baseline (search only main repo index):
+- Recall@5: 0.0
+- MRR: 0.0
+- No relevant hits for dependency queries
+
+Dependency index (search the dependency directly):
+- Recall@5: 1.0
+- MRR: 1.0
+- Avg time-to-first-relevant-hit: 3.93s
+
+### Benchmark 3: Storage + time
+
+Index sizes (from `tldr index list --cache-root ...`):
+- `main:llm-tldr`: ~2.53 MB
+- `dep:requests`: ~0.61 MB
+- Total cache root size: ~3.14 MB
+
+## Gotchas / Learnings
+
+- Semantic search stores file paths relative to the scan root. When indexing just the package directory, results look like `sessions.py` instead of `requests/sessions.py`. The benchmark matcher now accepts either a full path substring or matching basename.

--- a/scripts/bench_dep_indexes.py
+++ b/scripts/bench_dep_indexes.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Benchmark legacy vs index-mode semantic indexing for dependency sources.
+
+Runs three benchmarks:
+1) Parity: same corpus indexed legacy vs index mode (recall@k, MRR).
+2) Workflow: main-repo index vs dependency index (dependency queries).
+3) Storage + time: index time and disk usage for each index.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass
+class RunResult:
+    stdout: str
+    stderr: str
+    duration_s: float
+
+
+@dataclass
+class SearchMetrics:
+    recall_at_k: float
+    mrr: float
+    hits: int
+    total: int
+    avg_time_s: float | None
+    per_query: list[dict[str, Any]]
+
+
+def _run(cmd: list[str], env: dict[str, str]) -> RunResult:
+    start = time.perf_counter()
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    duration = time.perf_counter() - start
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Command failed: {' '.join(cmd)}\n"
+            f"stdout:\n{proc.stdout}\n"
+            f"stderr:\n{proc.stderr}"
+        )
+    return RunResult(stdout=proc.stdout, stderr=proc.stderr, duration_s=duration)
+
+
+def _run_tldr(args: list[str], env: dict[str, str]) -> RunResult:
+    cmd = [sys.executable, "-m", "tldr.cli", *args]
+    return _run(cmd, env)
+
+
+def _dir_size_bytes(path: Path) -> int:
+    total = 0
+    for root, _, files in os.walk(path):
+        for name in files:
+            file_path = Path(root) / name
+            try:
+                if file_path.is_symlink():
+                    continue
+                total += file_path.stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def _load_queries(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text())
+    if not isinstance(data, list):
+        raise ValueError("queries must be a JSON list")
+    return data
+
+
+def _resolve_package_root(dep: str) -> Path:
+    mod = importlib.import_module(dep)
+    mod_path = Path(mod.__file__).resolve()
+    if mod_path.name == "__init__.py":
+        return mod_path.parent
+    if (mod_path.parent / "__init__.py").exists():
+        return mod_path.parent
+    return mod_path
+
+
+def _copy_source(src: Path, dest: Path) -> Path:
+    if src.is_dir():
+        shutil.copytree(src, dest)
+        return dest
+    dest.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest / src.name)
+    return dest
+
+
+def _parse_indexed_count(output: str) -> int | None:
+    match = re.search(r"Indexed (\d+) code units", output)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _evaluate_queries(
+    queries: Iterable[dict[str, Any]],
+    search_fn,
+    k: int,
+) -> SearchMetrics:
+    hits = 0
+    total = 0
+    rr_sum = 0.0
+    time_hits: list[float] = []
+    per_query: list[dict[str, Any]] = []
+
+    for entry in queries:
+        query = entry["query"]
+        expected = entry["expect_path_contains"]
+        total += 1
+        results, duration_s = search_fn(query, k)
+
+        hit_rank = None
+        expected_norm = expected.replace("\\", "/")
+        expected_name = Path(expected_norm).name
+        for idx, result in enumerate(results, start=1):
+            path = result.get("file") or ""
+            path_norm = path.replace("\\", "/")
+            path_name = Path(path_norm).name
+            if expected_norm in path_norm or expected_name == path_name:
+                hit_rank = idx
+                break
+
+        if hit_rank is not None:
+            hits += 1
+            rr_sum += 1.0 / hit_rank
+            time_hits.append(duration_s)
+
+        per_query.append(
+            {
+                "query": query,
+                "expected": expected,
+                "hit_rank": hit_rank,
+                "duration_s": duration_s,
+                "top_path": results[0]["file"] if results else None,
+            }
+        )
+
+    recall = hits / total if total else 0.0
+    mrr = rr_sum / total if total else 0.0
+    avg_time = sum(time_hits) / len(time_hits) if time_hits else None
+
+    return SearchMetrics(
+        recall_at_k=recall,
+        mrr=mrr,
+        hits=hits,
+        total=total,
+        avg_time_s=avg_time,
+        per_query=per_query,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Benchmark isolated indexes")
+    parser.add_argument("--dep", default="requests", help="Dependency import name")
+    parser.add_argument(
+        "--queries",
+        default="scripts/bench_queries.json",
+        help="Path to queries JSON",
+    )
+    parser.add_argument("--k", type=int, default=5, help="Top-k for recall")
+    parser.add_argument("--lang", default="python", help="Language")
+    parser.add_argument(
+        "--model",
+        default="all-MiniLM-L6-v2",
+        help="Embedding model",
+    )
+    parser.add_argument("--device", default="cpu", help="Device")
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="Keep temp directories (print paths)",
+    )
+    args = parser.parse_args()
+
+    queries = _load_queries(Path(args.queries))
+    dep_root = _resolve_package_root(args.dep)
+
+    env = os.environ.copy()
+    env.setdefault("TLDR_AUTO_DOWNLOAD", "1")
+
+    with tempfile.TemporaryDirectory(prefix="tldr-bench-") as tmp:
+        tmp_path = Path(tmp)
+        legacy_src = tmp_path / f"{args.dep}-legacy"
+        index_src = tmp_path / f"{args.dep}-index"
+        cache_root = tmp_path / "cache-root"
+
+        _copy_source(dep_root, legacy_src)
+        _copy_source(dep_root, index_src)
+
+        # Parity: legacy index
+        legacy_index_start = time.perf_counter()
+        legacy_index_res = _run_tldr(
+            [
+                "semantic",
+                "index",
+                str(legacy_src),
+                "--lang",
+                args.lang,
+                "--model",
+                args.model,
+                "--device",
+                args.device,
+                "--no-ignore",
+            ],
+            env,
+        )
+        legacy_index_time = time.perf_counter() - legacy_index_start
+        legacy_units = _parse_indexed_count(legacy_index_res.stdout)
+
+        # Parity: index mode
+        dep_index_id = f"dep:{args.dep}"
+        index_index_start = time.perf_counter()
+        index_index_res = _run_tldr(
+            [
+                "--cache-root",
+                str(cache_root),
+                "--index",
+                dep_index_id,
+                "semantic",
+                "index",
+                str(index_src),
+                "--lang",
+                args.lang,
+                "--model",
+                args.model,
+                "--device",
+                args.device,
+                "--no-ignore",
+            ],
+            env,
+        )
+        index_index_time = time.perf_counter() - index_index_start
+        index_units = _parse_indexed_count(index_index_res.stdout)
+
+        def legacy_search(query: str, k: int):
+            res = _run_tldr(
+                [
+                    "semantic",
+                    "search",
+                    query,
+                    "--path",
+                    str(legacy_src),
+                    "--k",
+                    str(k),
+                    "--device",
+                    args.device,
+                ],
+                env,
+            )
+            results = json.loads(res.stdout)
+            return results, res.duration_s
+
+        def index_search(query: str, k: int):
+            res = _run_tldr(
+                [
+                    "--cache-root",
+                    str(cache_root),
+                    "--index",
+                    dep_index_id,
+                    "semantic",
+                    "search",
+                    query,
+                    "--path",
+                    str(index_src),
+                    "--k",
+                    str(k),
+                    "--device",
+                    args.device,
+                ],
+                env,
+            )
+            results = json.loads(res.stdout)
+            return results, res.duration_s
+
+        legacy_metrics = _evaluate_queries(queries, legacy_search, args.k)
+        index_metrics = _evaluate_queries(queries, index_search, args.k)
+
+        legacy_cache = legacy_src / ".tldr"
+        legacy_size = _dir_size_bytes(legacy_cache) if legacy_cache.exists() else 0
+
+        # Workflow benchmark: main repo index vs dependency index
+        repo_root = Path.cwd()
+        repo_scan = repo_root / "tldr"
+        main_index_id = "main:llm-tldr"
+        main_index_start = time.perf_counter()
+        _run_tldr(
+            [
+                "--cache-root",
+                str(cache_root),
+                "--index",
+                main_index_id,
+                "semantic",
+                "index",
+                str(repo_scan),
+                "--lang",
+                args.lang,
+                "--model",
+                args.model,
+                "--device",
+                args.device,
+                "--no-ignore",
+            ],
+            env,
+        )
+        main_index_time = time.perf_counter() - main_index_start
+
+        def main_search(query: str, k: int):
+            res = _run_tldr(
+                [
+                    "--cache-root",
+                    str(cache_root),
+                    "--index",
+                    main_index_id,
+                    "semantic",
+                    "search",
+                    query,
+                    "--path",
+                    str(repo_scan),
+                    "--k",
+                    str(k),
+                    "--device",
+                    args.device,
+                ],
+                env,
+            )
+            results = json.loads(res.stdout)
+            return results, res.duration_s
+
+        main_metrics = _evaluate_queries(queries, main_search, args.k)
+
+        index_list = _run_tldr(
+            ["--cache-root", str(cache_root), "index", "list"], env
+        )
+        index_list_data = json.loads(index_list.stdout)
+        index_sizes = {
+            entry.get("index_id"): entry.get("size_bytes")
+            for entry in index_list_data.get("indexes", [])
+        }
+
+        summary = {
+            "dependency": args.dep,
+            "dep_source": str(dep_root),
+            "model": args.model,
+            "device": args.device,
+            "k": args.k,
+            "paths": {
+                "legacy_src": str(legacy_src),
+                "index_src": str(index_src),
+                "cache_root": str(cache_root),
+                "repo_scan": str(repo_scan),
+            },
+            "parity": {
+                "legacy": {
+                    "index_time_s": legacy_index_time,
+                    "indexed_units": legacy_units,
+                    "disk_usage_bytes": legacy_size,
+                    "metrics": legacy_metrics.__dict__,
+                },
+                "index_mode": {
+                    "index_time_s": index_index_time,
+                    "indexed_units": index_units,
+                    "disk_usage_bytes": index_sizes.get(dep_index_id),
+                    "metrics": index_metrics.__dict__,
+                },
+            },
+            "workflow": {
+                "main_repo": {
+                    "index_time_s": main_index_time,
+                    "metrics": main_metrics.__dict__,
+                },
+                "dependency": {
+                    "metrics": index_metrics.__dict__,
+                },
+            },
+            "index_list": index_list_data,
+        }
+
+        print(json.dumps(summary, indent=2))
+
+        if args.keep:
+            print(f"\nKept temp data at: {tmp_path}")
+        else:
+            # TemporaryDirectory will clean up
+            pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_queries.json
+++ b/scripts/bench_queries.json
@@ -1,0 +1,12 @@
+[
+  {
+    "dep": "requests",
+    "query": "Session.request implementation",
+    "expect_path_contains": "requests/sessions.py"
+  },
+  {
+    "dep": "requests",
+    "query": "HTTPAdapter.send implementation",
+    "expect_path_contains": "requests/adapters.py"
+  }
+]

--- a/skills/llm-tldr-dep-indexer/SKILL.md
+++ b/skills/llm-tldr-dep-indexer/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: llm-tldr-dep-indexer
+description: Resolve exact installed dependency source and build isolated llm-tldr indexes. Prefer installed artifacts and only fetch repo/registry source when needed.
+---
+
+# llm-tldr Dependency Indexer
+
+Create accurate, isolated llm-tldr indexes for dependencies. This skill is **llm-tldr only**. It prefers installed artifacts and escalates to registry or VCS source only when the installed package is insufficient.
+
+## Quick Start
+
+Python:
+```bash
+uv run python /Users/aristotle/.agents/skills/llm-tldr-dep-indexer/scripts/resolve_python_dep.py torch
+```
+
+Node:
+```bash
+node /Users/aristotle/.agents/skills/llm-tldr-dep-indexer/scripts/resolve_node_dep.js lodash
+```
+
+Use the JSON output to choose a source path, then index:
+```bash
+tldr semantic index <SOURCE_PATH> \
+  --cache-root=git \
+  --index dep_<name>_<site|repo> \
+  --lang <python|javascript|all> \
+  --no-gitignore
+```
+
+Note: `--cache-root=git` resolves the repo root automatically and keeps a single `.tldr` cache per repo. Use a custom path if you want caches outside the repo.
+
+### Index Helper (refresh-aware)
+
+Use the helper to resolve the installed dependency, version it, and create/reuse the correct index automatically.
+
+Python:
+```bash
+python /Users/aristotle/.agents/skills/llm-tldr-dep-indexer/scripts/ensure_dep_index.py \
+  python requests
+```
+
+Node:
+```bash
+python /Users/aristotle/.agents/skills/llm-tldr-dep-indexer/scripts/ensure_dep_index.py \
+  node lodash
+```
+
+The helper:
+- Builds an index id like `dep:<name>@<version>:site` by default.
+- Uses `--cache-root=git` unless you override it.
+- Creates a new index when the version changes (or rebuilds if `--rebuild` is set).
+
+## Decision Rules (Default Behavior)
+
+1. **Local/editable install**
+   - If origin is local path or editable, index that local path.
+2. **Registry install**
+   - Index the installed artifact first (site-packages or node_modules).
+3. **Escalate only when needed**
+   - If installed artifact is opaque (native binaries, minified bundles, missing sources), fetch exact source from registry or VCS and index that too.
+4. **VCS install**
+   - If origin is VCS, clone the exact commit/tag and index it.
+
+## What Counts as “Opaque”
+
+Python (site-packages):
+- Many `.so/.pyd/.dylib` files and few `.py` sources.
+- You only see thin wrappers around compiled cores.
+
+JavaScript (node_modules):
+- Only `dist/` output and no `src/`, or heavy bundling/minification.
+- `.node` or `.wasm` present (native/WASM internals).
+
+## Exact Source Pulling
+
+Python (registry sdist, exact version):
+```bash
+uv pip download --no-binary :all: <pkg>==<ver>
+# extract the tar.gz, then index the extracted folder
+```
+
+Python (VCS):
+```bash
+git clone <repo> <dest>
+cd <dest>
+git checkout <tag-or-commit>
+```
+
+Node (registry tarball, exact version):
+```bash
+npm pack <pkg>@<ver>
+# extract the .tgz, then index the extracted folder
+```
+
+Node (VCS):
+```bash
+git clone <repo> <dest>
+cd <dest>
+git checkout <tag-or-commit>
+```
+
+## Index Naming Convention
+
+Use consistent names for clarity:
+- `dep_<name>_site` for installed artifacts
+- `dep_<name>_repo` for source repos
+
+## Cache Root Guidance
+
+Prefer `--cache-root=git` when running inside a repo to avoid scattering `.tldr` caches across subfolders. If you want caches outside the repo, set an explicit path (or `TLDR_CACHE_ROOT`) instead.
+
+## Outputs to Provide to User
+
+Always return:
+- Source path used for indexing
+- Version and origin (local/registry/vcs)
+- Index id(s) created
+- A scoped search command example
+
+## Scripts
+
+- `scripts/resolve_python_dep.py <dist_name> [--module <import_name>]`
+  - Emits JSON with version, install path, origin, and native extension indicators.
+- `scripts/resolve_node_dep.js <pkg> [--from <dir>]`
+  - Emits JSON with version, install path, and native/WASM indicators.
+- `scripts/ensure_dep_index.py <python|node> <name>`
+  - Resolves, versions, and (re)indexes dependencies using `--cache-root=git` by default.
+
+Use these scripts for deterministic resolution and provenance capture.

--- a/skills/llm-tldr-dep-indexer/scripts/ensure_dep_index.py
+++ b/skills/llm-tldr-dep-indexer/scripts/ensure_dep_index.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(cmd, env=None):
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    if result.returncode != 0:
+        raise SystemExit(
+            f"Command failed: {' '.join(cmd)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def _load_json(text):
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Failed to parse JSON: {exc}")
+
+
+def _tldr_prefix():
+    tldr_cmd = os.environ.get("TLDR_CMD", "tldr")
+    return shlex.split(tldr_cmd)
+
+
+def _resolve_python(dist, module):
+    resolver = Path(__file__).with_name("resolve_python_dep.py")
+    cmd = [sys.executable, str(resolver), dist]
+    if module:
+        cmd.extend(["--module", module])
+    out = _run(cmd)
+    data = _load_json(out)
+    return {
+        "name": data.get("dist_name") or dist,
+        "version": data.get("version"),
+        "code_root": data.get("code_root"),
+        "origin": data.get("origin"),
+        "raw": data,
+    }
+
+
+def _resolve_node(pkg, from_dir):
+    resolver = Path(__file__).with_name("resolve_node_dep.js")
+    cmd = ["node", str(resolver), pkg]
+    if from_dir:
+        cmd.extend(["--from", from_dir])
+    out = _run(cmd)
+    data = _load_json(out)
+    return {
+        "name": data.get("name") or pkg,
+        "version": data.get("version"),
+        "code_root": data.get("package_root"),
+        "origin": "registry",
+        "raw": data,
+    }
+
+
+def _build_index_id(name, version, kind):
+    base = f"dep:{name}"
+    if version:
+        base = f"{base}@{version}"
+    if kind:
+        base = f"{base}:{kind}"
+    return base
+
+
+def _index_list(cache_root):
+    cmd = _tldr_prefix() + ["--cache-root", cache_root, "index", "list"]
+    out = _run(cmd)
+    return _load_json(out)
+
+
+def _index_exists(index_list, index_id):
+    for entry in index_list.get("indexes", []):
+        if entry.get("index_id") == index_id:
+            return True
+    return False
+
+
+def _run_index(
+    *,
+    cache_root,
+    index_id,
+    code_root,
+    lang,
+    model,
+    device,
+    rebuild,
+    respect_gitignore,
+):
+    cmd = _tldr_prefix() + [
+        "--cache-root",
+        cache_root,
+        "--index",
+        index_id,
+        "semantic",
+        "index",
+        code_root,
+        "--lang",
+        lang,
+    ]
+    if model:
+        cmd.extend(["--model", model])
+    if device:
+        cmd.extend(["--device", device])
+    if rebuild:
+        cmd.append("--rebuild")
+    if not respect_gitignore:
+        cmd.append("--no-gitignore")
+    out = _run(cmd)
+    return out.strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Ensure a dependency index exists and is version-scoped.")
+    sub = parser.add_subparsers(dest="dep_type", required=True)
+
+    py_p = sub.add_parser("python", help="Ensure index for a Python dependency")
+    py_p.add_argument("dist", help="Distribution name (pip name)")
+    py_p.add_argument("--module", help="Import name (if different from dist)")
+
+    node_p = sub.add_parser("node", help="Ensure index for a Node dependency")
+    node_p.add_argument("pkg", help="Package name (npm)")
+    node_p.add_argument("--from", dest="from_dir", help="Resolve from a specific directory")
+
+    parser.add_argument("--cache-root", default="git", help="Cache root (default: git)")
+    parser.add_argument("--index-id", help="Override index id")
+    parser.add_argument("--kind", default="site", help="Suffix for index id (default: site)")
+    parser.add_argument("--lang", help="Language (defaults to python or javascript)")
+    parser.add_argument("--model", help="Embedding model")
+    parser.add_argument("--device", help="Embedding device")
+    parser.add_argument("--rebuild", action="store_true", help="Force rebuild")
+    parser.add_argument(
+        "--respect-gitignore",
+        action="store_true",
+        help="Respect gitignore (default: disabled for dependencies)",
+    )
+
+    args = parser.parse_args()
+
+    if args.dep_type == "python":
+        resolved = _resolve_python(args.dist, args.module)
+        lang = args.lang or "python"
+    else:
+        resolved = _resolve_node(args.pkg, args.from_dir)
+        lang = args.lang or "javascript"
+
+    code_root = resolved.get("code_root")
+    if not code_root:
+        raise SystemExit("Could not resolve code root for dependency.")
+
+    index_id = args.index_id or _build_index_id(
+        resolved.get("name"), resolved.get("version"), args.kind
+    )
+
+    index_list = _index_list(args.cache_root)
+    exists = _index_exists(index_list, index_id)
+
+    action = "reuse"
+    detail = None
+    if args.rebuild or not exists:
+        action = "rebuilt" if args.rebuild and exists else "created"
+        detail = _run_index(
+            cache_root=args.cache_root,
+            index_id=index_id,
+            code_root=code_root,
+            lang=lang,
+            model=args.model,
+            device=args.device,
+            rebuild=args.rebuild,
+            respect_gitignore=args.respect_gitignore,
+        )
+
+    result = {
+        "action": action,
+        "index_id": index_id,
+        "cache_root": args.cache_root,
+        "code_root": code_root,
+        "name": resolved.get("name"),
+        "version": resolved.get("version"),
+        "origin": resolved.get("origin"),
+        "detail": detail,
+        "resolver": resolved.get("raw"),
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/llm-tldr-dep-indexer/scripts/resolve_node_dep.js
+++ b/skills/llm-tldr-dep-indexer/scripts/resolve_node_dep.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const NATIVE_EXTS = new Set(['.node', '.wasm']);
+
+function parseArgs(argv) {
+  const args = { pkg: null, from: null };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!args.pkg && !arg.startsWith('--')) {
+      args.pkg = arg;
+      continue;
+    }
+    if (arg === '--from') {
+      args.from = argv[i + 1];
+      i++;
+      continue;
+    }
+  }
+  return args;
+}
+
+function resolvePackageJson(pkg, fromDir) {
+  const opts = fromDir ? { paths: [fromDir] } : undefined;
+  return require.resolve(`${pkg}/package.json`, opts);
+}
+
+function scanNative(root, maxFiles = 20000) {
+  let nativeCount = 0;
+  let scanned = 0;
+  let truncated = false;
+
+  const stack = [root];
+  while (stack.length) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      scanned += 1;
+      if (scanned > maxFiles) {
+        truncated = true;
+        return { nativeCount, truncated };
+      }
+      const ext = path.extname(entry.name).toLowerCase();
+      if (NATIVE_EXTS.has(ext)) {
+        nativeCount += 1;
+      }
+    }
+  }
+  return { nativeCount, truncated };
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (!args.pkg) {
+    console.error('Usage: resolve_node_dep.js <pkg> [--from <dir>]');
+    process.exit(1);
+  }
+
+  const pkgJsonPath = resolvePackageJson(args.pkg, args.from);
+  const pkgRoot = path.dirname(pkgJsonPath);
+  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+
+  const hasSrcDir = fs.existsSync(path.join(pkgRoot, 'src'));
+  const hasDistDir = fs.existsSync(path.join(pkgRoot, 'dist'));
+
+  const { nativeCount, truncated } = scanNative(pkgRoot);
+  const hasNativeExt = nativeCount > 0;
+
+  const result = {
+    name: pkgJson.name,
+    version: pkgJson.version,
+    package_json_path: pkgJsonPath,
+    package_root: pkgRoot,
+    entrypoints: {
+      main: pkgJson.main || null,
+      module: pkgJson.module || null,
+      types: pkgJson.types || pkgJson.typings || null,
+      exports: pkgJson.exports || null,
+    },
+    has_src_dir: hasSrcDir,
+    has_dist_dir: hasDistDir,
+    has_native_or_wasm: hasNativeExt,
+    native_file_count: nativeCount,
+    scan_truncated: truncated,
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main();

--- a/skills/llm-tldr-dep-indexer/scripts/resolve_python_dep.py
+++ b/skills/llm-tldr-dep-indexer/scripts/resolve_python_dep.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+from importlib import util as importlib_util
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+
+NATIVE_EXTS = {".so", ".pyd", ".dll", ".dylib"}
+
+
+def _find_dist_info(dist):
+    dist_info_dir = None
+    if dist.files:
+        for rel in dist.files:
+            rel_str = str(rel)
+            if rel_str.endswith("METADATA") and ".dist-info" in rel_str:
+                dist_info_dir = dist.locate_file(rel).parent
+                break
+    return dist_info_dir
+
+
+def _read_direct_url(dist_info_dir: Path | None):
+    if not dist_info_dir:
+        return None
+    direct_url = dist_info_dir / "direct_url.json"
+    if not direct_url.exists():
+        return None
+    try:
+        return json.loads(direct_url.read_text())
+    except Exception:
+        return None
+
+
+def _origin_from_direct_url(direct_url: dict | None) -> str:
+    if not direct_url:
+        return "registry"
+    if "vcs_info" in direct_url:
+        return "vcs"
+    dir_info = direct_url.get("dir_info")
+    if isinstance(dir_info, dict) and dir_info:
+        return "local"
+    if direct_url.get("url"):
+        return "url"
+    return "unknown"
+
+
+def _module_path(module_name: str | None):
+    if not module_name:
+        return None
+    spec = importlib_util.find_spec(module_name)
+    if spec is None:
+        return None
+    if spec.submodule_search_locations:
+        return str(Path(list(spec.submodule_search_locations)[0]).resolve())
+    if spec.origin:
+        return str(Path(spec.origin).resolve())
+    return None
+
+
+def _scan_native_exts(root: Path, max_files: int = 20000):
+    py_count = 0
+    native_count = 0
+    scanned = 0
+    truncated = False
+    for dirpath, _, filenames in os.walk(root):
+        for name in filenames:
+            scanned += 1
+            if scanned > max_files:
+                truncated = True
+                return py_count, native_count, truncated
+            ext = Path(name).suffix.lower()
+            if ext == ".py":
+                py_count += 1
+            elif ext in NATIVE_EXTS:
+                native_count += 1
+    return py_count, native_count, truncated
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Resolve Python dependency install info")
+    parser.add_argument("dist", help="Distribution name (pip name)")
+    parser.add_argument("--module", help="Import name (if different from dist)")
+    args = parser.parse_args()
+
+    try:
+        dist = importlib_metadata.distribution(args.dist)
+    except importlib_metadata.PackageNotFoundError:
+        raise SystemExit(f"Package not found: {args.dist}")
+
+    version = dist.version
+    dist_info_dir = _find_dist_info(dist)
+    direct_url = _read_direct_url(dist_info_dir)
+    origin = _origin_from_direct_url(direct_url)
+
+    module_name = args.module or args.dist
+    module_path = _module_path(module_name)
+
+    code_root = None
+    if module_path:
+        path = Path(module_path)
+        code_root = str(path if path.is_dir() else path.parent)
+
+    py_count = None
+    native_count = None
+    truncated = None
+    has_native_ext = None
+    if code_root and Path(code_root).exists():
+        py_count, native_count, truncated = _scan_native_exts(Path(code_root))
+        has_native_ext = native_count > 0
+
+    result = {
+        "dist_name": args.dist,
+        "version": version,
+        "module_name": module_name,
+        "module_path": module_path,
+        "code_root": code_root,
+        "dist_info_path": str(dist_info_dir) if dist_info_dir else None,
+        "direct_url": direct_url,
+        "origin": origin,
+        "py_file_count": py_count,
+        "native_file_count": native_count,
+        "has_native_ext": has_native_ext,
+        "scan_truncated": truncated,
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/llm-tldr-usage/SKILL.md
+++ b/skills/llm-tldr-usage/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: llm-tldr-usage
+description: Use when Codex needs to operate llm-tldr (tldr CLI) to index, search, or analyze a codebase. Covers warm/semantic/context/search/impact/slice workflows, daemon usage, .tldrignore handling, index isolation with --cache-root and --index, and index management via tldr index list/info/rm.
+---
+
+# Llm Tldr Usage
+
+## Overview
+Use this skill to drive llm-tldr CLI workflows for indexing and querying codebases. Prefer index mode with `--cache-root=git` to keep all `.tldr` data under the repo root and avoid scattered caches.
+
+## Quick Start
+1. Index the current repo (structural caches):
+```bash
+tldr warm --cache-root=git .
+```
+2. Build semantic embeddings (one-time per index):
+```bash
+tldr semantic index --cache-root=git .
+```
+3. Ask a behavioral question:
+```bash
+tldr semantic search "describe how auth tokens are validated" --cache-root=git --path .
+```
+4. Pull focused context for an edit:
+```bash
+tldr context login --cache-root=git --project .
+```
+
+## Choose The Right Path
+- Index the current repo and search it.
+- Index a dependency with an isolated index id.
+- Manage existing indexes under a shared cache root.
+
+## Index A Repo (Default Case)
+- Build indexes:
+```bash
+tldr warm --cache-root=git /path/to/repo
+```
+- Build semantic embeddings:
+```bash
+tldr semantic index --cache-root=git /path/to/repo
+```
+- Search semantically:
+```bash
+tldr semantic search "retry logic for network calls" --cache-root=git --path /path/to/repo
+```
+- Use structural tools when you need precise code shape:
+```bash
+tldr structure src/ --lang python --cache-root=git /path/to/repo
+```
+
+## Index A Dependency (Isolated)
+Use an explicit index id so dependency data does not mix with the main repo.
+
+1. Pick an index id format that is stable and versioned, for example:
+`dep:<name>@<version>:site`
+2. Create or rebuild the dependency index:
+```bash
+tldr warm --cache-root=git --index dep:requests@2.31.0:site /path/to/site-packages/requests
+```
+3. Query the dependency directly:
+```bash
+tldr semantic search "Session.request implementation" --cache-root=git --index dep:requests@2.31.0:site --path /path/to/site-packages/requests
+```
+
+If the dependency path or version is unknown, run the dependency indexer skill helper first:
+```bash
+python skills/llm-tldr-dep-indexer/scripts/ensure_dep_index.py python requests
+```
+Use the returned `index_id` and `scan_root` for subsequent `tldr` commands.
+
+## Example: Repo + Dependency Under One Cache Root
+With `--cache-root=git`, all indexes created inside a repo live under the repo-root `.tldr/` regardless of where you run the command.
+
+Dependency index (stored under repo root):
+```bash
+# Build the dependency index
+uv run tldr --cache-root=git --index dep:requests \
+  semantic index .venv/lib/python3.12/site-packages/requests --lang python
+
+# Query it
+uv run tldr --cache-root=git --index dep:requests \
+  semantic search "HTTPAdapter.send implementation" \
+  --path .venv/lib/python3.12/site-packages/requests
+```
+
+Repo index (same cache root, different index id):
+```bash
+# Build the repo index
+uv run tldr --cache-root=git --index repo:llm-tldr \
+  semantic index . --lang python
+
+# Query it
+uv run tldr --cache-root=git --index repo:llm-tldr \
+  semantic search "daemon status handling" --path .
+```
+
+Where they live on disk:
+```text
+<repo>/.tldr/indexes/<hash-of-dep:requests>/
+<repo>/.tldr/indexes/<hash-of-repo:llm-tldr>/
+```
+
+Can they both be searched? Yes, but one at a time in the current CLI. You switch scopes by changing `--index`.
+
+## Index Management (List, Inspect, Delete)
+Use these to keep a clean cache and verify what exists.
+
+- List indexes:
+```bash
+tldr index list --cache-root=git
+```
+- Inspect one index:
+```bash
+tldr index info --cache-root=git dep:requests@2.31.0:site
+```
+- Remove an index:
+```bash
+tldr index rm --cache-root=git dep:requests@2.31.0:site
+```
+
+## Query Toolkit
+Pick the smallest tool that answers the question.
+
+- Quick file tree: `tldr tree <path>`
+- Surface API structure: `tldr structure <path> --lang <lang>`
+- Text search: `tldr search "pattern" <path>`
+- Function context: `tldr context <func> --project <path>`
+- Callers: `tldr impact <func> <path>`
+- Program slice: `tldr slice <file> <func> <line>`
+- Semantic search: `tldr semantic search "natural language query" --path <path>`
+
+Always include `--cache-root=git` (and `--index` if used) so queries hit the intended index.
+
+## Daemon Workflow
+Use the daemon when running many queries in a session.
+
+```bash
+tldr daemon start --cache-root=git --project /path/to/repo
+```
+Notify the daemon on file changes to keep caches fresh:
+```bash
+tldr daemon notify /path/to/repo/src/auth.py --cache-root=git --project /path/to/repo
+```
+
+## Ignore Files And Scope
+- Prefer `.tldrignore` for persistent exclusions.
+- Use `--ignore` for ad-hoc exclusions and `--no-ignore` to override.
+
+```bash
+tldr --ignore "fixtures/" --ignore "*.generated.ts" tree .
+```
+
+## Notes And Gotchas
+- `--index` requires `--cache-root`. Use `--cache-root=git` inside a git repo.
+- When `--cache-root=git` is not available, pass a concrete path instead.
+- Without `--index`, llm-tldr derives an index id from the scan root relative to the cache root.
+- `.tldrignore` is index-scoped in index mode, so each isolated index can have its own ignore rules.
+
+## References
+Load these repo docs when you need full CLI detail or copy-ready examples:
+- `README.md`
+- `docs/TLDR.md`

--- a/skills/llm-tldr-usage/agents/openai.yaml
+++ b/skills/llm-tldr-usage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LLM TLDR Usage"
+  short_description: "Guide agents to index and search code with llm-tldr CLI"
+  default_prompt: "Help me use llm-tldr to index and query codebases or dependencies."

--- a/specs/001-feat-isolated-index.md
+++ b/specs/001-feat-isolated-index.md
@@ -1,0 +1,95 @@
+ **Problem**
+  - When LLMs encounter an issue with an installed depdendency and need more information they have a tendency to try to search the internet or github with poor search semantics and often going on wild goose chases (adding the year in the search parameters, or github fails to return the response) and even when the response returns the web docs are incomplte or don't match the installed dependency version.
+  - llm-tldr/tldr intentionally ignores heavy dependency dirs (node_modules/, .venv/) by default; indexing them wholesale is slow and produces noisy mixed results.
+  - TLDR currently conflates “what you scan” with “where caches live”: indexing a dep in-place tends to write .tldr//.tldrignore into the dep directory, and semantic indexing tends to collide in a single repo-level cache unless you isolate it.
+
+  **Solution (today)**
+  - Keep one “main” index for your repo (deps excluded), then allowlist only the specific dep(s) you need via .tldrignore (e.g. prefer node_modules/* + !node_modules/pkg/** instead of ignoring node_modules/ entirely).
+  - For deep “how does this library work?” questions, build a separate per-dependency index keyed by name@version and query that (often by mirroring the dep into a dedicated analysis root to avoid writing into node_modules/ / site-packages/).
+  - In agent/MCP usage, prefer TLDR results first and only web-search if TLDR can’t answer.
+
+  **Solution (feature needed in llm-tldr to make this clean/lazy without copying)**
+
+  - Add a first-class Index concept: --scan-root (dep path) + --cache-root (repo root) + --index (module@version or hash), with all caches namespaced under repo/.tldr/ indexes/<index_id>/... (call graph + semantic FAISS + metadata + index-scoped ignore), plus daemon/MCP multi-index support and index management commands (list/info/rm/gc).
+
+
+Goal
+  Enable “index this dependency in-place, but store all TLDR state under the repo root” with one index per module@version, without copying.
+
+  1. Add A First-Class “Index” Concept
+
+  1. Define an index as {cache_root, scan_root, index_id, language(s), model, ignore_spec}.
+  2. Make index_id deterministic and user-overridable (e.g. node:zod@3.23.8), and store meta.json alongside caches.
+
+  2. Decouple Scan Root From Cache Root (Core Feature)
+
+  1. Add global CLI flags (or equivalent env vars):
+      1. --cache-root <path>: where .tldr/… lives (repo root).
+      2. --scan-root <path>: what directory to analyze (dep directory).
+      3. --index <id>: selects/creates an isolated namespace under cache_root.
+  2. Ensure all commands accept these flags (at least: warm, semantic index/search, tree, structure, search, context, calls, impact, imports, importers).
+
+  3. Namespaced Cache Layout
+
+  1. Move from single global cache files to per-index directories:
+      1. cache_root/.tldr/indexes/<index_id>/meta.json
+      2. cache_root/.tldr/indexes/<index_id>/call_graph.json
+      3. cache_root/.tldr/indexes/<index_id>/languages.json
+      4. cache_root/.tldr/indexes/<index_id>/semantic/index.faiss
+      5. cache_root/.tldr/indexes/<index_id>/semantic/metadata.json
+  2. Keep current behavior as the default “index” for backward compatibility.
+
+  4. Fix Semantic Indexing Root Assumptions
+
+  1. Stop auto-walking upward to find “project root” for semantic cache placement when --cache-root/--index is provided.
+  2. Make semantic build/search always read/write from the per-index semantic directory.
+  3. Store and enforce the embedding model in meta.json/semantic metadata to prevent accidental mismatch.
+
+  5. Make Ignore Specs Index-Scoped
+
+  1. Add --ignore-file <path> and/or “index-local ignore file” support:
+      1. Default to cache_root/.tldr/indexes/<index_id>/.tldrignore (not scan_root/.tldrignore).
+  2. Add --use-gitignore/--no-gitignore because dependencies are often not in the repo’s gitignore context.
+
+  6. Update Daemon + MCP To Support Multiple Indexes
+
+  1. Include index_id (and scan_root) in daemon startup/config.
+  2. Make the daemon socket path keyed by (cache_root, index_id) (simplest “one daemon per index”).
+  3. Update daemon commands to accept --index and route requests to the correct index config.
+  4. Update tldr-mcp server to accept --index and to set env vars/args accordingly.
+
+  7. Add Index Management Commands (Needed For A Skill)
+
+  1. tldr index list --cache-root …
+  2. tldr index info <index_id>
+  3. tldr index rm <index_id>
+  4. tldr index gc (optional; based on age/size)
+
+  8. Tests / Validation
+
+  1. Unit tests for index path resolution (no collisions across two deps).
+  2. Integration test that builds two indexes under one repo root and verifies:
+      1. semantic search results differ and load the right FAISS files.
+      2. warm caches don’t overwrite each other.
+      3. daemon queries for --index A never read caches for --index B.
+
+  With those features, the skill becomes straightforward: resolve dep path + version, derive index_id, then run tldr … --cache-root <repo> --scan-root <dep> --index <id>
+  for warm/search without copying or web search
+
+  Why these steps:
+
+• - Index ID / per-module namespace: prevents “semantic search for auth” from mixing results across multiple dependencies, and prevents cache files (call graph, FAISS
+    index, metadata) from overwriting each other when you index more than one package.
+  - Decouple scan_root from cache_root: lets you analyze code where it lives (node_modules/foo, site-packages/bar) while keeping all TLDR state in one predictable,
+    writable place (repo/.tldr/...). This avoids writing into dependency directories (often ephemeral, read-only, or managed by package managers).
+  - Namespaced cache layout: makes multiple indexes coexist safely. Without this, TLDR has “one cache location per repo” semantics, so the last indexed thing wins.
+  - Fix semantic “project root” assumptions: TLDR currently decides where to put semantic caches by walking up to .git/package.json. If you point it at a dependency
+    inside a repo, it tends to store into the repo’s single semantic cache, which collides with other indexes. Explicit cache_root/index_id makes it deterministic.
+  - Index-scoped ignore configuration: deps have very different “what matters” than your app. You want ignore rules that are specific to that dependency (and don’t rely
+    on the repo’s .gitignore), while still not creating .tldrignore inside node_modules.
+  - Daemon/MCP multi-index support: the “fast 100ms queries” daemon is only useful if it can serve the correct index. If it’s only keyed by project path, you can’t
+    safely have zod@x and auth0@y loaded simultaneously.
+  - Index management commands: a skill needs to “lazy load” and clean up. list/info/rm/gc are how you avoid silently growing .tldr/ forever and how you can detect
+    “already indexed for this version”.
+  - Tests: this feature is mostly about avoiding subtle collisions (wrong index loaded, wrong model used, stale cache). Tests are what keep it from regressing as TLDR
+    evolves.

--- a/specs/001-feat-isolated-index.md
+++ b/specs/001-feat-isolated-index.md
@@ -16,6 +16,14 @@
 Goal
   Enable “index this dependency in-place, but store all TLDR state under the repo root” with one index per module@version, without copying.
 
+  **Phases (recommended delivery slices)**
+  - Phase 1 (MVP: isolated index + semantic): items 1–4 + a minimal subset of tests to prove per-index cache separation.
+  - Phase 2 (Ignore scoping + CLI completeness): item 5 + ensure ignore config is index-scoped and no writes occur under scan_root.
+  - Phase 3 (Daemon + MCP): item 6 + one-daemon-per-index identity/routing; add the daemon isolation test.
+  - Phase 4 (Index management): item 7 (+ optional gc) + UX/docs polish.
+
+  (The numbered requirements below remain the full list; phases are a suggested sequencing for implementation/PRs.)
+
   1. Add A First-Class “Index” Concept
 
   1. Define an index as {cache_root, scan_root, index_id, language(s), model, ignore_spec}.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+import sys
+import types
+
+
+if "pygments_tldr" not in sys.modules:
+    pkg = types.ModuleType("pygments_tldr")
+    pkg.highlight = lambda *args, **kwargs: ""
+
+    formatters = types.ModuleType("pygments_tldr.formatters")
+    tldr_mod = types.ModuleType("pygments_tldr.formatters.tldr")
+    lexers = types.ModuleType("pygments_tldr.lexers")
+    util = types.ModuleType("pygments_tldr.util")
+
+    class TLDRFormatter:
+        pass
+
+    tldr_mod.TLDRFormatter = TLDRFormatter
+    formatters.tldr = tldr_mod
+    pkg.formatters = formatters
+
+    lexers.get_lexer_for_filename = lambda *args, **kwargs: None
+    lexers.get_lexer_by_name = lambda *args, **kwargs: None
+    pkg.lexers = lexers
+
+    class ClassNotFound(Exception):
+        pass
+
+    util.ClassNotFound = ClassNotFound
+    pkg.util = util
+
+    sys.modules["pygments_tldr"] = pkg
+    sys.modules["pygments_tldr.formatters"] = formatters
+    sys.modules["pygments_tldr.formatters.tldr"] = tldr_mod
+    sys.modules["pygments_tldr.lexers"] = lexers
+    sys.modules["pygments_tldr.util"] = util

--- a/tests/test_cache_root_git.py
+++ b/tests/test_cache_root_git.py
@@ -1,0 +1,58 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tldr.indexing import get_index_context
+
+
+def _git_available() -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "--version"], capture_output=True, text=True, timeout=5
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+@pytest.mark.skipif(not _git_available(), reason="git not available")
+def test_cache_root_git_uses_repo_root_from_scan_root(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+
+    scan_root = repo / "sub" / "dir"
+    scan_root.mkdir(parents=True)
+
+    ctx = get_index_context(
+        scan_root=scan_root,
+        cache_root_arg="git",
+        index_id_arg=None,
+        allow_create=True,
+    )
+
+    assert ctx.cache_root == repo.resolve()
+    assert ctx.index_id == "path:sub/dir"
+
+
+@pytest.mark.skipif(not _git_available(), reason="git not available")
+def test_cache_root_git_falls_back_to_cwd(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    monkeypatch.chdir(repo)
+
+    ctx = get_index_context(
+        scan_root=outside,
+        cache_root_arg="git",
+        index_id_arg=None,
+        allow_create=True,
+    )
+
+    assert ctx.cache_root == repo.resolve()
+    assert ctx.index_id.startswith("abs:")

--- a/tests/test_cli_parsing_index_flags.py
+++ b/tests/test_cli_parsing_index_flags.py
@@ -1,0 +1,21 @@
+from tldr.cli import build_parser
+
+
+def test_index_flags_parse_before_subcommand():
+    parser = build_parser()
+    args = parser.parse_args(
+        ["--cache-root", "/tmp/cache", "warm", "/tmp/project", "--index", "dep:test"]
+    )
+    assert args.cache_root == "/tmp/cache"
+    assert args.index_id == "dep:test"
+    assert args.command == "warm"
+
+
+def test_index_flags_parse_after_subcommand():
+    parser = build_parser()
+    args = parser.parse_args(
+        ["warm", "/tmp/project", "--cache-root", "/tmp/cache", "--index", "dep:test"]
+    )
+    assert args.cache_root == "/tmp/cache"
+    assert args.index_id == "dep:test"
+    assert args.command == "warm"

--- a/tests/test_daemon_identity.py
+++ b/tests/test_daemon_identity.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import importlib.util
+import sys
+
+
+def _load_identity_module():
+    module_path = Path(__file__).resolve().parents[1] / "tldr" / "daemon" / "identity.py"
+    spec = importlib.util.spec_from_file_location("tldr.daemon.identity", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load tldr.daemon.identity module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+identity_module = _load_identity_module()
+resolve_daemon_identity = identity_module.resolve_daemon_identity
+
+
+def test_daemon_identity_isolated(tmp_path: Path):
+    cache_root = tmp_path / "cache"
+    cache_root_alt = tmp_path / "cache_alt"
+    scan_root = tmp_path / "scan"
+    scan_root_alt = tmp_path / "scan_alt"
+    cache_root.mkdir()
+    cache_root_alt.mkdir()
+    scan_root.mkdir()
+    scan_root_alt.mkdir()
+
+    id_a = resolve_daemon_identity(scan_root, cache_root=cache_root, index_id="dep:a")
+    id_b = resolve_daemon_identity(scan_root, cache_root=cache_root, index_id="dep:b")
+    assert id_a.hash != id_b.hash
+
+    id_same = resolve_daemon_identity(scan_root_alt, cache_root=cache_root, index_id="dep:a")
+    assert id_same.hash == id_a.hash
+
+    id_other_cache = resolve_daemon_identity(scan_root, cache_root=cache_root_alt, index_id="dep:a")
+    assert id_other_cache.hash != id_a.hash
+
+    legacy = resolve_daemon_identity(scan_root)
+    assert legacy.hash != id_a.hash

--- a/tests/test_daemon_index_mode.py
+++ b/tests/test_daemon_index_mode.py
@@ -1,0 +1,237 @@
+import importlib.util
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _load_identity_module():
+    module_path = Path(__file__).resolve().parents[1] / "tldr" / "daemon" / "identity.py"
+    spec = importlib.util.spec_from_file_location("tldr.daemon.identity", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load tldr.daemon.identity module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+identity_module = _load_identity_module()
+resolve_daemon_identity = identity_module.resolve_daemon_identity
+get_connection_info = identity_module.get_connection_info
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _module_available(name: str) -> bool:
+    module = sys.modules.get(name)
+    if module is not None and getattr(module, "__spec__", None) is None:
+        return False
+    try:
+        return importlib.util.find_spec(name) is not None
+    except ValueError:
+        return False
+
+
+def _write_stub(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _ensure_stub_modules(stub_root: Path) -> bool:
+    needs_stub = False
+
+    if not _module_available("pygments_tldr"):
+        needs_stub = True
+        _write_stub(
+            stub_root / "pygments_tldr" / "__init__.py",
+            "def highlight(code, lexer, formatter):\n    return code\n",
+        )
+        _write_stub(
+            stub_root / "pygments_tldr" / "formatters" / "__init__.py",
+            "",
+        )
+        _write_stub(
+            stub_root / "pygments_tldr" / "formatters" / "tldr.py",
+            "class TLDRFormatter:\n    def __init__(self, **kwargs):\n        self.options = kwargs\n",
+        )
+        _write_stub(
+            stub_root / "pygments_tldr" / "lexers" / "__init__.py",
+            "class _DummyLexer:\n    aliases = [\"text\"]\n\n"
+            "def get_lexer_for_filename(filename):\n    return _DummyLexer()\n\n"
+            "def get_lexer_by_name(name):\n    return _DummyLexer()\n",
+        )
+        _write_stub(
+            stub_root / "pygments_tldr" / "util.py",
+            "class ClassNotFound(Exception):\n    pass\n",
+        )
+
+    if not _module_available("tiktoken"):
+        needs_stub = True
+        _write_stub(
+            stub_root / "tiktoken" / "__init__.py",
+            "class Encoding:\n"
+            "    def encode(self, text):\n"
+            "        if not text:\n"
+            "            return []\n"
+            "        return list(text)\n\n"
+            "def get_encoding(name):\n"
+            "    return Encoding()\n",
+        )
+
+    return needs_stub
+
+
+def _build_subprocess_env(tmp_path: Path) -> dict | None:
+    stub_root = tmp_path / "daemon_stubs"
+    if not _ensure_stub_modules(stub_root):
+        return None
+
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        f"{stub_root}{os.pathsep}{pythonpath}" if pythonpath else str(stub_root)
+    )
+    return env
+
+
+def _start_daemon_process(
+    project: Path,
+    cache_root: Path,
+    index_id: str,
+    *,
+    env: dict | None = None,
+) -> subprocess.Popen:
+    cmd = [
+        sys.executable,
+        "-m",
+        "tldr.daemon",
+        str(project),
+        "--cache-root",
+        str(cache_root),
+        "--index",
+        index_id,
+        "--foreground",
+    ]
+    return subprocess.Popen(
+        cmd,
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+
+
+def _wait_for_daemon(identity, proc: subprocess.Popen, timeout: float = 10.0) -> None:
+    start = time.monotonic()
+    last_error = None
+    while time.monotonic() - start < timeout:
+        if proc.poll() is not None:
+            raise AssertionError(f"Daemon exited early with code {proc.returncode}")
+
+        addr, port = get_connection_info(identity)
+        try:
+            if port is None:
+                if not Path(addr).exists():
+                    time.sleep(0.05)
+                    continue
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.settimeout(0.2)
+                sock.connect(addr)
+            else:
+                sock = socket.create_connection((addr, port), timeout=0.2)
+            sock.close()
+            return
+        except OSError as exc:
+            last_error = exc
+            time.sleep(0.05)
+
+    raise AssertionError(f"Daemon did not become ready: {last_error}")
+
+
+def _send_command(identity, payload: dict, timeout: float = 1.0) -> dict:
+    addr, port = get_connection_info(identity)
+    data = json.dumps(payload).encode() + b"\n"
+
+    if port is None:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        sock.connect(addr)
+    else:
+        sock = socket.create_connection((addr, port), timeout=timeout)
+        sock.settimeout(timeout)
+
+    try:
+        sock.sendall(data)
+        response = b""
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            response += chunk
+            if b"\n" in response:
+                break
+        return json.loads(response.decode().strip())
+    finally:
+        sock.close()
+
+
+def _stop_daemon(identity, proc: subprocess.Popen) -> None:
+    try:
+        _send_command(identity, {"cmd": "shutdown"}, timeout=1.0)
+    except Exception:
+        pass
+
+    if proc.poll() is not None:
+        return
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_daemon_index_mode_isolated_sockets(tmp_path: Path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "README.md").write_text("hello\n")
+
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+
+    index_a = "dep:a"
+    index_b = "dep:b"
+
+    env = _build_subprocess_env(tmp_path)
+    proc_a = _start_daemon_process(project, cache_root, index_a, env=env)
+    proc_b = _start_daemon_process(project, cache_root, index_b, env=env)
+
+    identity_a = resolve_daemon_identity(project, cache_root=cache_root, index_id=index_a)
+    identity_b = resolve_daemon_identity(project, cache_root=cache_root, index_id=index_b)
+
+    try:
+        _wait_for_daemon(identity_a, proc_a)
+        _wait_for_daemon(identity_b, proc_b)
+
+        addr_a, port_a = get_connection_info(identity_a)
+        addr_b, port_b = get_connection_info(identity_b)
+        assert (addr_a, port_a) != (addr_b, port_b)
+
+        if port_a is None:
+            assert Path(addr_a).exists()
+            assert Path(addr_b).exists()
+        else:
+            assert port_a != port_b
+
+        assert _send_command(identity_a, {"cmd": "ping"}).get("status") == "ok"
+        assert _send_command(identity_b, {"cmd": "ping"}).get("status") == "ok"
+    finally:
+        _stop_daemon(identity_a, proc_a)
+        _stop_daemon(identity_b, proc_b)

--- a/tests/test_ignore_index_scoped.py
+++ b/tests/test_ignore_index_scoped.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+import pytest
+
+from tldr.cross_file_calls import scan_project
+from tldr.indexing import get_index_context
+from tldr.tldrignore import IgnoreSpec
+
+
+def test_index_scoped_ignore_file_applies(tmp_path: Path):
+    pytest.importorskip("pathspec")
+    cache_root = tmp_path / "repo"
+    scan_root = tmp_path / "dep"
+    cache_root.mkdir()
+    scan_root.mkdir()
+
+    (scan_root / "keep.py").write_text("def keep():\n    return 1\n")
+    (scan_root / "ignored.py").write_text("def ignored():\n    return 2\n")
+    (scan_root / ".tldrignore").write_text("# empty\n")
+
+    ctx = get_index_context(
+        scan_root=scan_root,
+        cache_root_arg=cache_root,
+        index_id_arg="dep:ignore",
+        allow_create=True,
+    )
+
+    ignore_path = ctx.paths.ignore_file
+    ignore_path.parent.mkdir(parents=True, exist_ok=True)
+    ignore_path.write_text("ignored.py\n")
+
+    cfg = ctx.config
+    ignore_spec = IgnoreSpec(
+        project_dir=scan_root,
+        use_gitignore=cfg.use_gitignore,
+        cli_patterns=list(cfg.cli_patterns or ()),
+        ignore_file=cfg.ignore_file,
+        gitignore_root=cfg.gitignore_root,
+    )
+
+    files = scan_project(
+        scan_root,
+        language="python",
+        respect_ignore=True,
+        ignore_spec=ignore_spec,
+    )
+    file_names = {Path(f).name for f in files}
+    assert "keep.py" in file_names
+    assert "ignored.py" not in file_names
+
+
+def test_ignore_file_change_invalidates_call_graph(tmp_path: Path):
+    cache_root = tmp_path / "repo"
+    scan_root = tmp_path / "dep"
+    cache_root.mkdir()
+    scan_root.mkdir()
+
+    (scan_root / "mod.py").write_text("def foo():\n    return 1\n")
+
+    ctx = get_index_context(
+        scan_root=scan_root,
+        cache_root_arg=cache_root,
+        index_id_arg="dep:invalidate",
+        allow_create=True,
+    )
+
+    ignore_path = ctx.paths.ignore_file
+    ignore_path.parent.mkdir(parents=True, exist_ok=True)
+    ignore_path.write_text("ignored.py\n")
+
+    ctx.paths.call_graph.parent.mkdir(parents=True, exist_ok=True)
+    ctx.paths.call_graph.write_text('{"edges": []}')
+    assert ctx.paths.call_graph.exists()
+
+    # Change ignore file contents -> should invalidate caches without rebind
+    ignore_path.write_text("ignored.py\nother.py\n")
+
+    get_index_context(
+        scan_root=scan_root,
+        cache_root_arg=cache_root,
+        index_id_arg="dep:invalidate",
+        allow_create=False,
+    )
+
+    assert not ctx.paths.call_graph.exists()

--- a/tests/test_index_management.py
+++ b/tests/test_index_management.py
@@ -1,0 +1,118 @@
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from tldr import cli
+from tldr.indexing import compute_index_key, get_index_context
+from tldr.indexing.management import gc_indexes, remove_index
+
+
+def _create_index(cache_root: Path, scan_root: Path, index_id: str) -> None:
+    get_index_context(
+        scan_root=scan_root,
+        cache_root_arg=cache_root,
+        index_id_arg=index_id,
+        allow_create=True,
+        force_rebind=False,
+        ignore_file_arg=None,
+        use_gitignore_arg=False,
+        cli_patterns_arg=None,
+        no_ignore_arg=False,
+    )
+
+
+def test_index_cli_list_info_rm(tmp_path: Path, monkeypatch, capsys):
+    cache_root = tmp_path / "repo"
+    scan_root = tmp_path / "dep"
+    cache_root.mkdir()
+    scan_root.mkdir()
+    (scan_root / "mod.py").write_text("def foo():\n    return 1\n")
+
+    index_id = "dep:test"
+    _create_index(cache_root, scan_root, index_id)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["tldr", "index", "list", "--cache-root", str(cache_root)],
+    )
+    cli.main()
+    data = json.loads(capsys.readouterr().out)
+    assert any(entry["index_id"] == index_id for entry in data["indexes"])
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "tldr",
+            "index",
+            "info",
+            index_id,
+            "--cache-root",
+            str(cache_root),
+        ],
+    )
+    cli.main()
+    info = json.loads(capsys.readouterr().out)
+    assert info["index_id"] == index_id
+    assert info["meta"]["index_id"] == index_id
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["tldr", "index", "rm", index_id, "--cache-root", str(cache_root)],
+    )
+    cli.main()
+    removed = json.loads(capsys.readouterr().out)
+    assert removed["removed"] is True
+    assert not (cache_root / ".tldr" / "indexes" / removed["index_key"]).exists()
+
+
+def test_index_rm_requires_force_when_daemon_running(tmp_path: Path, monkeypatch):
+    cache_root = tmp_path / "repo"
+    scan_root = tmp_path / "dep"
+    cache_root.mkdir()
+    scan_root.mkdir()
+
+    index_id = "dep:running"
+    _create_index(cache_root, scan_root, index_id)
+
+    from tldr.indexing import management
+
+    monkeypatch.setattr(management, "_daemon_running", lambda *args, **kwargs: True)
+    with pytest.raises(ValueError):
+        remove_index(cache_root, index_id, force=False)
+
+    result = remove_index(cache_root, index_id, force=True)
+    assert result["removed"] is True
+
+
+def test_index_gc_removes_old(tmp_path: Path):
+    cache_root = tmp_path / "repo"
+    scan_root_a = tmp_path / "dep_a"
+    scan_root_b = tmp_path / "dep_b"
+    cache_root.mkdir()
+    scan_root_a.mkdir()
+    scan_root_b.mkdir()
+
+    index_a = "dep:old"
+    index_b = "dep:new"
+    _create_index(cache_root, scan_root_a, index_a)
+    _create_index(cache_root, scan_root_b, index_b)
+
+    meta_path = (
+        cache_root
+        / ".tldr"
+        / "indexes"
+        / compute_index_key(index_a)
+        / "meta.json"
+    )
+    meta = json.loads(meta_path.read_text())
+    meta["last_used_at"] = (
+        datetime.now(timezone.utc) - timedelta(days=10)
+    ).isoformat().replace("+00:00", "Z")
+    meta_path.write_text(json.dumps(meta, indent=2))
+
+    result = gc_indexes(cache_root, days=7, max_total_mb=None, force=False)
+    removed_ids = {entry["index_id"] for entry in result["removed"]}
+    assert index_a in removed_ids
+    assert index_b not in removed_ids

--- a/tests/test_index_paths.py
+++ b/tests/test_index_paths.py
@@ -12,17 +12,29 @@ def test_index_key_deterministic():
 def test_index_paths_distinct(tmp_path: Path):
     cache_root = tmp_path / "repo"
     scan_root = tmp_path / "scan"
+    index_key_a = compute_index_key("dep:a")
+    index_key_b = compute_index_key("dep:b")
     config_a = IndexConfig(
         cache_root=cache_root,
         scan_root=scan_root,
         index_id="dep:a",
-        index_key=compute_index_key("dep:a"),
+        index_key=index_key_a,
+        ignore_file=cache_root / ".tldr" / "indexes" / index_key_a / ".tldrignore",
+        use_gitignore=True,
+        gitignore_root=cache_root,
+        cli_patterns=None,
+        no_ignore=False,
     )
     config_b = IndexConfig(
         cache_root=cache_root,
         scan_root=scan_root,
         index_id="dep:b",
-        index_key=compute_index_key("dep:b"),
+        index_key=index_key_b,
+        ignore_file=cache_root / ".tldr" / "indexes" / index_key_b / ".tldrignore",
+        use_gitignore=True,
+        gitignore_root=cache_root,
+        cli_patterns=None,
+        no_ignore=False,
     )
     paths_a = IndexPaths.from_config(config_a)
     paths_b = IndexPaths.from_config(config_b)

--- a/tests/test_index_paths.py
+++ b/tests/test_index_paths.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from tldr.indexing import IndexConfig, IndexPaths, compute_index_key
+
+
+def test_index_key_deterministic():
+    key1 = compute_index_key("node:zod@3.23.8")
+    key2 = compute_index_key("node:zod@3.23.8")
+    assert key1 == key2
+
+
+def test_index_paths_distinct(tmp_path: Path):
+    cache_root = tmp_path / "repo"
+    scan_root = tmp_path / "scan"
+    config_a = IndexConfig(
+        cache_root=cache_root,
+        scan_root=scan_root,
+        index_id="dep:a",
+        index_key=compute_index_key("dep:a"),
+    )
+    config_b = IndexConfig(
+        cache_root=cache_root,
+        scan_root=scan_root,
+        index_id="dep:b",
+        index_key=compute_index_key("dep:b"),
+    )
+    paths_a = IndexPaths.from_config(config_a)
+    paths_b = IndexPaths.from_config(config_b)
+    assert paths_a.index_dir != paths_b.index_dir

--- a/tests/test_no_writes_outside_cache_root.py
+++ b/tests/test_no_writes_outside_cache_root.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from tldr.indexing import compute_index_key
+from tldr import cli
+
+
+def test_warm_does_not_write_under_scan_root(tmp_path: Path, monkeypatch):
+    cache_root = tmp_path / "repo"
+    scan_root = tmp_path / "dep"
+    cache_root.mkdir()
+    scan_root.mkdir()
+
+    (scan_root / "mod.py").write_text("def foo():\n    return 1\n")
+
+    index_id = "dep:test"
+    argv = [
+        "tldr",
+        "warm",
+        str(scan_root),
+        "--cache-root",
+        str(cache_root),
+        "--index",
+        index_id,
+        "--lang",
+        "python",
+    ]
+    monkeypatch.setattr("sys.argv", argv)
+    cli.main()
+
+    assert not (scan_root / ".tldr").exists()
+    assert not (scan_root / ".tldrignore").exists()
+
+    index_key = compute_index_key(index_id)
+    call_graph = cache_root / ".tldr" / "indexes" / index_key / "cache" / "call_graph.json"
+    assert call_graph.exists()

--- a/tests/test_semantic_index_isolated.py
+++ b/tests/test_semantic_index_isolated.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tldr.indexing import get_index_context
+from tldr.semantic import build_semantic_index, semantic_search
+
+
+class DummyModel:
+    def encode(self, texts, batch_size=None, normalize_embeddings=True, show_progress_bar=False):
+        if isinstance(texts, str):
+            texts = [texts]
+        return np.zeros((len(texts), 3), dtype=np.float32)
+
+
+def test_semantic_indexes_isolated(tmp_path, monkeypatch):
+    pytest.importorskip("faiss")
+    cache_root = tmp_path / "repo"
+    cache_root.mkdir()
+
+    scan_a = tmp_path / "dep_a"
+    scan_b = tmp_path / "dep_b"
+    scan_a.mkdir()
+    scan_b.mkdir()
+
+    (scan_a / "a.py").write_text("def func_a():\n    return 1\n")
+    (scan_b / "b.py").write_text("def func_b():\n    return 2\n")
+
+    monkeypatch.setattr("tldr.semantic.get_model", lambda *_args, **_kwargs: DummyModel())
+
+    ctx_a = get_index_context(
+        scan_root=scan_a,
+        cache_root_arg=cache_root,
+        index_id_arg="dep:a",
+        allow_create=True,
+    )
+    ctx_b = get_index_context(
+        scan_root=scan_b,
+        cache_root_arg=cache_root,
+        index_id_arg="dep:b",
+        allow_create=True,
+    )
+
+    build_semantic_index(
+        str(scan_a),
+        lang="python",
+        model="dummy-model",
+        show_progress=False,
+        index_paths=ctx_a.paths,
+        index_config=ctx_a.config,
+    )
+    build_semantic_index(
+        str(scan_b),
+        lang="python",
+        model="dummy-model",
+        show_progress=False,
+        index_paths=ctx_b.paths,
+        index_config=ctx_b.config,
+    )
+
+    assert ctx_a.paths.semantic_metadata.exists()
+    assert ctx_b.paths.semantic_metadata.exists()
+    assert ctx_a.paths.semantic_metadata != ctx_b.paths.semantic_metadata
+
+    results = semantic_search(
+        str(scan_a),
+        "function",
+        model="dummy-model",
+        index_paths=ctx_a.paths,
+        index_config=ctx_a.config,
+    )
+    assert results
+    assert all("a.py" in r.get("file", "") for r in results)

--- a/tests/test_workspace_config_rebase.py
+++ b/tests/test_workspace_config_rebase.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import json
+
+from tldr.cross_file_calls import scan_project
+from tldr.workspace import load_workspace_config
+
+
+def test_workspace_config_rebase(tmp_path: Path):
+    cache_root = tmp_path / "repo"
+    scan_root = cache_root / "packages" / "foo"
+    (scan_root / "src").mkdir(parents=True)
+    (scan_root / "dist").mkdir(parents=True)
+
+    (scan_root / "src" / "keep.py").write_text("def keep():\n    return 1\n")
+    (scan_root / "dist" / "ignored.py").write_text("def ignore():\n    return 2\n")
+
+    claude_dir = cache_root / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "workspace.json").write_text(
+        json.dumps({"excludePatterns": ["**/dist/**"]})
+    )
+
+    config = load_workspace_config(cache_root)
+    files = scan_project(
+        scan_root,
+        "python",
+        workspace_config=config,
+        workspace_root=cache_root,
+        respect_ignore=False,
+    )
+    files_str = [str(Path(f)) for f in files]
+    assert any("keep.py" in f for f in files_str)
+    assert not any("dist/ignored.py" in f for f in files_str)

--- a/tldr/analysis.py
+++ b/tldr/analysis.py
@@ -368,6 +368,7 @@ def analyze_impact(
     max_depth: int = 3,
     target_file: str | None = None,
     language: str = "python",
+    workspace_root: str | None = None,
 ) -> dict:
     """Convenience wrapper that builds call graph from path.
 
@@ -383,7 +384,9 @@ def analyze_impact(
     """
     from .api import build_project_call_graph
 
-    call_graph = build_project_call_graph(path, language=language)
+    call_graph = build_project_call_graph(
+        path, language=language, workspace_root=workspace_root
+    )
     return impact_analysis(call_graph, target_func, max_depth, target_file)
 
 
@@ -391,6 +394,7 @@ def analyze_dead_code(
     path: str,
     entry_points: list[str] | None = None,
     language: str = "python",
+    workspace_root: str | None = None,
 ) -> dict:
     """Convenience wrapper that builds call graph from path.
 
@@ -404,7 +408,9 @@ def analyze_dead_code(
     """
     from .api import build_project_call_graph, get_code_structure
 
-    call_graph = build_project_call_graph(path, language=language)
+    call_graph = build_project_call_graph(
+        path, language=language, workspace_root=workspace_root
+    )
     structure = get_code_structure(path, language=language, max_results=1000)
 
     # Build function list from structure
@@ -417,7 +423,11 @@ def analyze_dead_code(
     return dead_code_analysis(call_graph, all_functions, entry_points)
 
 
-def analyze_architecture(path: str, language: str = "python") -> dict:
+def analyze_architecture(
+    path: str,
+    language: str = "python",
+    workspace_root: str | None = None,
+) -> dict:
     """Convenience wrapper that builds call graph from path.
 
     Args:
@@ -429,5 +439,7 @@ def analyze_architecture(path: str, language: str = "python") -> dict:
     """
     from .api import build_project_call_graph
 
-    call_graph = build_project_call_graph(path, language=language)
+    call_graph = build_project_call_graph(
+        path, language=language, workspace_root=workspace_root
+    )
     return architecture_analysis(call_graph)

--- a/tldr/analysis.py
+++ b/tldr/analysis.py
@@ -368,6 +368,7 @@ def analyze_impact(
     max_depth: int = 3,
     target_file: str | None = None,
     language: str = "python",
+    ignore_spec=None,
     workspace_root: str | None = None,
 ) -> dict:
     """Convenience wrapper that builds call graph from path.
@@ -385,7 +386,10 @@ def analyze_impact(
     from .api import build_project_call_graph
 
     call_graph = build_project_call_graph(
-        path, language=language, workspace_root=workspace_root
+        path,
+        language=language,
+        ignore_spec=ignore_spec,
+        workspace_root=workspace_root,
     )
     return impact_analysis(call_graph, target_func, max_depth, target_file)
 
@@ -394,6 +398,7 @@ def analyze_dead_code(
     path: str,
     entry_points: list[str] | None = None,
     language: str = "python",
+    ignore_spec=None,
     workspace_root: str | None = None,
 ) -> dict:
     """Convenience wrapper that builds call graph from path.
@@ -409,9 +414,17 @@ def analyze_dead_code(
     from .api import build_project_call_graph, get_code_structure
 
     call_graph = build_project_call_graph(
-        path, language=language, workspace_root=workspace_root
+        path,
+        language=language,
+        ignore_spec=ignore_spec,
+        workspace_root=workspace_root,
     )
-    structure = get_code_structure(path, language=language, max_results=1000)
+    structure = get_code_structure(
+        path,
+        language=language,
+        max_results=1000,
+        ignore_spec=ignore_spec,
+    )
 
     # Build function list from structure
     all_functions = []
@@ -426,6 +439,7 @@ def analyze_dead_code(
 def analyze_architecture(
     path: str,
     language: str = "python",
+    ignore_spec=None,
     workspace_root: str | None = None,
 ) -> dict:
     """Convenience wrapper that builds call graph from path.
@@ -440,6 +454,9 @@ def analyze_architecture(
     from .api import build_project_call_graph
 
     call_graph = build_project_call_graph(
-        path, language=language, workspace_root=workspace_root
+        path,
+        language=language,
+        ignore_spec=ignore_spec,
+        workspace_root=workspace_root,
     )
     return architecture_analysis(call_graph)

--- a/tldr/api.py
+++ b/tldr/api.py
@@ -527,7 +527,8 @@ def get_relevant_context(
     entry_point: str,
     depth: int = 2,
     language: str = "python",
-    include_docstrings: bool = True
+    include_docstrings: bool = True,
+    workspace_root: str | None = None,
 ) -> RelevantContext:
     """
     Get token-efficient context for an LLM starting from an entry point.
@@ -563,7 +564,9 @@ def get_relevant_context(
     # (e.g., "main/" or with extension) for module exports.
 
     # Build cross-file call graph
-    call_graph = build_project_call_graph(str(project), language=language)
+    call_graph = build_project_call_graph(
+        str(project), language=language, workspace_root=workspace_root
+    )
 
     # Index all signatures
     extractor = HybridExtractor()

--- a/tldr/api.py
+++ b/tldr/api.py
@@ -17,7 +17,6 @@ Usage:
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
 from .ast_extractor import (
     CallGraphInfo,  # Re-exported for API consumers
@@ -153,11 +152,11 @@ from .dfg_extractor import (
     extract_swift_dfg,
     extract_typescript_dfg,
 )
-from .hybrid_extractor import (
+from .hybrid_extractor import (  # noqa: F401
     HybridExtractor,
     extract_directory,  # Re-exported for API
 )
-from .pdg_extractor import (
+from .pdg_extractor import (  # noqa: F401
     PDGInfo,
     extract_c_pdg,
     extract_cpp_pdg,
@@ -550,15 +549,6 @@ def get_relevant_context(
     # Module query mode: path with / and no . (e.g., "providers/anthropic")
     if "/" in entry_point and "." not in entry_point:
         return _get_module_exports(project, entry_point, language, include_docstrings)
-
-    # Check if entry_point is a module name (no / or .)
-    # e.g., "unified_gate" -> check for unified_gate.py
-    ext_for_lang = {
-        "python": ".py",
-        "typescript": ".ts",
-        "go": ".go",
-        "rust": ".rs"
-    }.get(language, ".py")
 
     # NOTE: Removed module-file shortcut that conflicted with function lookup.
     # If entry_point="main" matched "main.ts", it would return module exports
@@ -1638,7 +1628,6 @@ def get_code_structure(
             # Collect class methods
             methods = []
             for cls in info_dict.get("classes", []):
-                cls_name = cls.get("name", "")
                 for method in cls.get("methods", []):
                     method_name = method.get("name", "")
                     if method_name:

--- a/tldr/cfg_extractor.py
+++ b/tldr/cfg_extractor.py
@@ -11,7 +11,6 @@ Based on staticfg pattern but simplified for TLDR-code use case.
 """
 import ast
 from dataclasses import dataclass, field
-from typing import Any
 
 # Tree-sitter imports (optional)
 TREE_SITTER_AVAILABLE = False
@@ -19,105 +18,104 @@ TREE_SITTER_GO_AVAILABLE = False
 TREE_SITTER_RUST_AVAILABLE = False
 
 try:
-    from tree_sitter import Language, Parser
-    import tree_sitter_typescript
-    import tree_sitter_javascript
+    import tree_sitter_typescript  # noqa: F401
+    import tree_sitter_javascript  # noqa: F401
     TREE_SITTER_AVAILABLE = True
 except ImportError:
     pass
 
 try:
-    import tree_sitter_go
+    import tree_sitter_go  # noqa: F401
     TREE_SITTER_GO_AVAILABLE = True
 except ImportError:
     pass
 
 try:
-    import tree_sitter_rust
+    import tree_sitter_rust  # noqa: F401
     TREE_SITTER_RUST_AVAILABLE = True
 except ImportError:
     pass
 
 TREE_SITTER_JAVA_AVAILABLE = False
 try:
-    import tree_sitter_java
+    import tree_sitter_java  # noqa: F401
     TREE_SITTER_JAVA_AVAILABLE = True
 except ImportError:
     pass
 
 TREE_SITTER_C_AVAILABLE = False
 try:
-    import tree_sitter_c
+    import tree_sitter_c  # noqa: F401
     TREE_SITTER_C_AVAILABLE = True
 except ImportError:
     pass
 
 TREE_SITTER_RUBY_AVAILABLE = False
 try:
-    import tree_sitter_ruby
+    import tree_sitter_ruby  # noqa: F401
     TREE_SITTER_RUBY_AVAILABLE = True
 except ImportError:
     pass
 
 TREE_SITTER_PHP_AVAILABLE = False
 try:
-    import tree_sitter_php
+    import tree_sitter_php  # noqa: F401
     TREE_SITTER_PHP_AVAILABLE = True
 except ImportError:
     pass
 
 TREE_SITTER_CPP_AVAILABLE = False
 try:
-    import tree_sitter_cpp
+    import tree_sitter_cpp  # noqa: F401
     TREE_SITTER_CPP_AVAILABLE = True
 except ImportError:
     pass
 
 TREE_SITTER_SWIFT_AVAILABLE = False
 try:
-    import tree_sitter_swift
+    import tree_sitter_swift  # noqa: F401
     TREE_SITTER_SWIFT_AVAILABLE = True
 except ImportError:
     pass
 
 TREE_SITTER_CSHARP_AVAILABLE = False
 try:
-    import tree_sitter_c_sharp
+    import tree_sitter_c_sharp  # noqa: F401
     TREE_SITTER_CSHARP_AVAILABLE = True
 except ImportError:
     pass
 
 TREE_SITTER_KOTLIN_AVAILABLE = False
 try:
-    import tree_sitter_kotlin
+    import tree_sitter_kotlin  # noqa: F401
     TREE_SITTER_KOTLIN_AVAILABLE = True
 except ImportError:
     pass
 
 TREE_SITTER_SCALA_AVAILABLE = False
 try:
-    import tree_sitter_scala
+    import tree_sitter_scala  # noqa: F401
     TREE_SITTER_SCALA_AVAILABLE = True
 except ImportError:
     pass
 
 TREE_SITTER_ELIXIR_AVAILABLE = False
 try:
-    import tree_sitter_elixir
+    import tree_sitter_elixir  # noqa: F401
     TREE_SITTER_ELIXIR_AVAILABLE = True
 except ImportError:
     pass
 
 TREE_SITTER_LUA_AVAILABLE = False
 try:
-    import tree_sitter_lua
+    import tree_sitter_lua  # noqa: F401
     TREE_SITTER_LUA_AVAILABLE = True
 except ImportError:
     pass
 
 TREE_SITTER_LUAU_AVAILABLE = False
 try:
-    import tree_sitter_luau
+    import tree_sitter_luau  # noqa: F401
     TREE_SITTER_LUAU_AVAILABLE = True
 except ImportError:
     pass
@@ -1123,9 +1121,6 @@ class TreeSitterCFGBuilder:
         else:
             branch = self.new_block("branch", node.start_point[0] + 1)
             branch_block_id = branch.id
-
-        # Get condition text (guard condition)
-        condition = self.get_node_text(node)
 
         # Create after-guard block for normal flow (guard passes)
         after_guard = self.new_block("body", node.end_point[0] + 1)

--- a/tldr/change_impact.py
+++ b/tldr/change_impact.py
@@ -154,6 +154,7 @@ def find_affected_tests(
     changed_files: list[str],
     language: str = "python",
     max_depth: int = 5,
+    workspace_root: str | None = None,
 ) -> dict:
     """
     Find test files affected by changes to the given files.
@@ -204,6 +205,7 @@ def find_affected_tests(
                 func_name,
                 max_depth=max_depth,
                 language=language,
+                workspace_root=workspace_root,
             )
 
             # Walk the caller tree and collect test files
@@ -312,6 +314,7 @@ def analyze_change_impact(
     git_base: str = "HEAD~1",
     language: str = "python",
     max_depth: int = 5,
+    workspace_root: str | None = None,
 ) -> dict:
     """
     Main entry point for change impact analysis.
@@ -386,6 +389,7 @@ def analyze_change_impact(
         source_files + test_files,
         language=language,
         max_depth=max_depth,
+        workspace_root=workspace_root,
     )
     result["source"] = source
 

--- a/tldr/change_impact.py
+++ b/tldr/change_impact.py
@@ -112,6 +112,7 @@ def find_tests_importing_module(
     project_path: str,
     module_name: str,
     language: str = "python",
+    ignore_spec=None,
 ) -> list[str]:
     """
     Find test files that import a given module.
@@ -123,7 +124,11 @@ def find_tests_importing_module(
     importing_tests = []
 
     try:
-        all_files = scan_project_files(str(project), language=language)
+        all_files = scan_project_files(
+            str(project),
+            language=language,
+            ignore_spec=ignore_spec,
+        )
         test_files = [f for f in all_files if is_test_file(f)]
 
         for test_file in test_files:
@@ -154,6 +159,7 @@ def find_affected_tests(
     changed_files: list[str],
     language: str = "python",
     max_depth: int = 5,
+    ignore_spec=None,
     workspace_root: str | None = None,
 ) -> dict:
     """
@@ -205,6 +211,7 @@ def find_affected_tests(
                 func_name,
                 max_depth=max_depth,
                 language=language,
+                ignore_spec=ignore_spec,
                 workspace_root=workspace_root,
             )
 
@@ -239,14 +246,18 @@ def find_affected_tests(
         module_name = get_module_name(str(abs_path), str(project))
         if module_name:
             importing_tests = find_tests_importing_module(
-                str(project), module_name, language
+                str(project), module_name, language, ignore_spec=ignore_spec
             )
             affected_tests.update(importing_tests)
 
     # Count total test files for skip calculation
     all_test_files = []
     try:
-        all_files = scan_project_files(str(project), language=language)
+        all_files = scan_project_files(
+            str(project),
+            language=language,
+            ignore_spec=ignore_spec,
+        )
         all_test_files = [f for f in all_files if is_test_file(f)]
     except Exception:
         pass
@@ -314,6 +325,7 @@ def analyze_change_impact(
     git_base: str = "HEAD~1",
     language: str = "python",
     max_depth: int = 5,
+    ignore_spec=None,
     workspace_root: str | None = None,
 ) -> dict:
     """
@@ -389,6 +401,7 @@ def analyze_change_impact(
         source_files + test_files,
         language=language,
         max_depth=max_depth,
+        ignore_spec=ignore_spec,
         workspace_root=workspace_root,
     )
     result["source"] = source

--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -120,7 +120,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     index_parent.add_argument(
         "--cache-root",
-        help="Directory where .tldr caches live (enables index mode)",
+        help="Directory where .tldr caches live (enables index mode). Use 'git' to resolve the repo root.",
     )
     index_parent.add_argument(
         "--index",

--- a/tldr/cross_file_calls.py
+++ b/tldr/cross_file_calls.py
@@ -18,7 +18,7 @@ import ast
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Optional
 
 from tldr.workspace import WorkspaceConfig, load_workspace_config, filter_paths
 
@@ -3899,7 +3899,6 @@ def _build_java_call_graph(
                     # Object.method() call
                     if '.' in call_target:
                         parts = call_target.split('.')
-                        obj_name = parts[0]
                         method_name = parts[-1]
 
                         # Try to find the method in the function index
@@ -3939,7 +3938,6 @@ def _build_c_call_graph(
 
         for inc in includes:
             module = inc['module']
-            is_system = inc.get('is_system', False)
             # Map the header file name to its path
             # e.g., "utils.h" -> "utils.h"
             header_name = module.split('/')[-1] if '/' in module else module

--- a/tldr/daemon/cached_queries.py
+++ b/tldr/daemon/cached_queries.py
@@ -11,11 +11,15 @@ from tldr.salsa import SalsaDB, salsa_query
 
 
 @salsa_query
-def cached_search(db: SalsaDB, project: str, pattern: str, max_results: int) -> dict:
+def cached_search(
+    db: SalsaDB,
+    project: str,
+    pattern: str,
+    max_results: int,
+    ignore_spec=None,
+) -> dict:
     """Cached search query - memoized by SalsaDB."""
     from tldr import api
-    from tldr.tldrignore import IgnoreSpec
-    ignore_spec = IgnoreSpec(project, use_gitignore=True)
     results = api.search(pattern=pattern, root=Path(project), max_results=max_results, ignore_spec=ignore_spec)
     return {"status": "ok", "results": results}
 
@@ -29,20 +33,44 @@ def cached_extract(db: SalsaDB, file_path: str) -> dict:
 
 
 @salsa_query
-def cached_dead_code(db: SalsaDB, project: str, entry_points: tuple, language: str) -> dict:
+def cached_dead_code(
+    db: SalsaDB,
+    project: str,
+    entry_points: tuple,
+    language: str,
+    ignore_spec=None,
+    workspace_root=None,
+) -> dict:
     """Cached dead code analysis - memoized by SalsaDB."""
     from tldr.analysis import analyze_dead_code
     # Convert tuple back to list for the API
     entry_list = list(entry_points) if entry_points else None
-    result = analyze_dead_code(project, entry_points=entry_list, language=language)
+    result = analyze_dead_code(
+        project,
+        entry_points=entry_list,
+        language=language,
+        ignore_spec=ignore_spec,
+        workspace_root=workspace_root,
+    )
     return {"status": "ok", "result": result}
 
 
 @salsa_query
-def cached_architecture(db: SalsaDB, project: str, language: str) -> dict:
+def cached_architecture(
+    db: SalsaDB,
+    project: str,
+    language: str,
+    ignore_spec=None,
+    workspace_root=None,
+) -> dict:
     """Cached architecture analysis - memoized by SalsaDB."""
     from tldr.analysis import analyze_architecture
-    result = analyze_architecture(project, language=language)
+    result = analyze_architecture(
+        project,
+        language=language,
+        ignore_spec=ignore_spec,
+        workspace_root=workspace_root,
+    )
     return {"status": "ok", "result": result}
 
 
@@ -72,31 +100,59 @@ def cached_slice(db: SalsaDB, file_path: str, function: str, line: int, directio
 
 
 @salsa_query
-def cached_tree(db: SalsaDB, project: str, extensions: tuple, exclude_hidden: bool) -> dict:
+def cached_tree(
+    db: SalsaDB,
+    project: str,
+    extensions: tuple,
+    exclude_hidden: bool,
+    ignore_spec=None,
+) -> dict:
     """Cached file tree - memoized by SalsaDB."""
     from tldr.api import get_file_tree
-    from tldr.tldrignore import IgnoreSpec
     ext_set = set(extensions) if extensions else None
-    ignore_spec = IgnoreSpec(project, use_gitignore=True)
-    result = get_file_tree(project, extensions=ext_set, exclude_hidden=exclude_hidden, ignore_spec=ignore_spec)
+    result = get_file_tree(
+        project,
+        extensions=ext_set,
+        exclude_hidden=exclude_hidden,
+        ignore_spec=ignore_spec,
+    )
     return {"status": "ok", "result": result}
 
 
 @salsa_query
-def cached_structure(db: SalsaDB, project: str, language: str, max_results: int) -> dict:
+def cached_structure(
+    db: SalsaDB,
+    project: str,
+    language: str,
+    max_results: int,
+    ignore_spec=None,
+) -> dict:
     """Cached code structure - memoized by SalsaDB."""
     from tldr.api import get_code_structure
-    from tldr.tldrignore import IgnoreSpec
-    ignore_spec = IgnoreSpec(project, use_gitignore=True)
     result = get_code_structure(project, language=language, max_results=max_results, ignore_spec=ignore_spec)
     return {"status": "ok", "result": result}
 
 
 @salsa_query
-def cached_context(db: SalsaDB, project: str, entry: str, language: str, depth: int) -> dict:
+def cached_context(
+    db: SalsaDB,
+    project: str,
+    entry: str,
+    language: str,
+    depth: int,
+    ignore_spec=None,
+    workspace_root=None,
+) -> dict:
     """Cached relevant context - memoized by SalsaDB."""
     from tldr.api import get_relevant_context
-    result = get_relevant_context(project, entry, language=language, depth=depth)
+    result = get_relevant_context(
+        project,
+        entry,
+        language=language,
+        depth=depth,
+        ignore_spec=ignore_spec,
+        workspace_root=workspace_root,
+    )
     return {"status": "ok", "result": result}
 
 
@@ -109,11 +165,17 @@ def cached_imports(db: SalsaDB, file_path: str, language: str) -> dict:
 
 
 @salsa_query
-def cached_importers(db: SalsaDB, project: str, module: str, language: str) -> dict:
+def cached_importers(
+    db: SalsaDB,
+    project: str,
+    module: str,
+    language: str,
+    ignore_spec=None,
+) -> dict:
     """Cached reverse import lookup - memoized by SalsaDB."""
     from tldr.api import get_imports, scan_project_files
 
-    files = scan_project_files(project, language=language)
+    files = scan_project_files(project, language=language, ignore_spec=ignore_spec)
     importers = []
     project_path = Path(project)
 

--- a/tldr/daemon/identity.py
+++ b/tldr/daemon/identity.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from tldr.indexing import compute_index_key, derive_index_id, IndexConfig, IndexContext
+
+
+@dataclass(frozen=True)
+class DaemonIdentity:
+    mode: Literal["legacy", "index"]
+    scan_root: Path
+    cache_root: Path | None
+    index_id: str | None
+    index_key: str | None
+    seed: str
+    hash: str
+
+
+def resolve_daemon_identity(
+    scan_root: str | Path,
+    *,
+    cache_root: str | Path | None = None,
+    index_id: str | None = None,
+    index_key: str | None = None,
+) -> DaemonIdentity:
+    scan_root_path = Path(scan_root).resolve()
+    if cache_root is None:
+        seed = str(scan_root_path)
+        digest = hashlib.md5(seed.encode()).hexdigest()[:8]
+        return DaemonIdentity(
+            mode="legacy",
+            scan_root=scan_root_path,
+            cache_root=None,
+            index_id=None,
+            index_key=None,
+            seed=seed,
+            hash=digest,
+        )
+
+    cache_root_path = Path(cache_root).resolve()
+    if index_key is None:
+        if index_id is None:
+            index_id = derive_index_id(scan_root_path, cache_root_path)
+        index_key = compute_index_key(index_id)
+
+    seed = f"{cache_root_path}\0{index_key}"
+    digest = hashlib.md5(seed.encode()).hexdigest()[:8]
+    return DaemonIdentity(
+        mode="index",
+        scan_root=scan_root_path,
+        cache_root=cache_root_path,
+        index_id=index_id,
+        index_key=index_key,
+        seed=seed,
+        hash=digest,
+    )
+
+
+def resolve_daemon_identity_from_context(
+    index_ctx: IndexContext | None,
+    *,
+    scan_root: str | Path | None = None,
+) -> DaemonIdentity:
+    if index_ctx is not None and index_ctx.cache_root is not None:
+        return resolve_daemon_identity(
+            index_ctx.scan_root,
+            cache_root=index_ctx.cache_root,
+            index_id=index_ctx.index_id,
+            index_key=index_ctx.index_key,
+        )
+    if scan_root is None:
+        raise ValueError("scan_root is required when no index context is provided")
+    return resolve_daemon_identity(scan_root)
+
+
+def resolve_daemon_identity_from_config(config: IndexConfig) -> DaemonIdentity:
+    return resolve_daemon_identity(
+        config.scan_root,
+        cache_root=config.cache_root,
+        index_id=config.index_id,
+        index_key=config.index_key,
+    )
+
+
+def get_lock_path(identity: DaemonIdentity) -> Path:
+    tmp_dir = tempfile.gettempdir()
+    return Path(tmp_dir) / f"tldr-{identity.hash}.lock"
+
+
+def get_pid_path(identity: DaemonIdentity) -> Path:
+    tmp_dir = tempfile.gettempdir()
+    return Path(tmp_dir) / f"tldr-{identity.hash}.pid"
+
+
+def get_socket_path(identity: DaemonIdentity) -> Path:
+    tmp_dir = tempfile.gettempdir()
+    return Path(tmp_dir) / f"tldr-{identity.hash}.sock"
+
+
+def get_port_path(identity: DaemonIdentity) -> Path:
+    tmp_dir = tempfile.gettempdir()
+    return Path(tmp_dir) / f"tldr-{identity.hash}.port"
+
+
+def read_port_file(identity: DaemonIdentity) -> int | None:
+    port_path = get_port_path(identity)
+    if not port_path.exists():
+        return None
+    try:
+        value = port_path.read_text().strip()
+        if not value:
+            return None
+        return int(value)
+    except (OSError, ValueError):
+        return None
+
+
+def write_port_file(identity: DaemonIdentity, port: int) -> None:
+    port_path = get_port_path(identity)
+    port_path.write_text(str(port))
+
+
+def clear_port_file(identity: DaemonIdentity) -> None:
+    port_path = get_port_path(identity)
+    try:
+        port_path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def get_connection_info(identity: DaemonIdentity) -> tuple[str, int | None]:
+    """Return (address, port) - port is None for Unix sockets."""
+    if sys.platform == "win32":
+        port = read_port_file(identity)
+        if port is None:
+            port = 49152 + (int(identity.hash, 16) % 10000)
+        return ("127.0.0.1", port)
+    socket_path = get_socket_path(identity)
+    return (str(socket_path), None)

--- a/tldr/daemon/startup.py
+++ b/tldr/daemon/startup.py
@@ -6,17 +6,27 @@ The lock is held for the daemon's entire lifetime, preventing duplicates.
 Cross-platform: fcntl.flock() on Unix, msvcrt.locking() on Windows.
 """
 
-import hashlib
 import json
 import logging
 import os
 import socket
 import sys
-import tempfile
 import time
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, IO
+
+from tldr.indexing import IndexContext, get_index_context
+
+from .identity import (
+    DaemonIdentity,
+    get_connection_info,
+    get_lock_path,
+    get_pid_path,
+    get_socket_path,
+    resolve_daemon_identity,
+    resolve_daemon_identity_from_context,
+)
 
 # Platform-specific imports for file locking
 if sys.platform == "win32":
@@ -30,25 +40,33 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _get_lock_path(project: Path) -> Path:
+def _resolve_identity(
+    project: Path,
+    *,
+    index_ctx: IndexContext | None = None,
+    cache_root: Path | None = None,
+    index_id: str | None = None,
+) -> DaemonIdentity:
+    if index_ctx is not None:
+        return resolve_daemon_identity_from_context(index_ctx, scan_root=project)
+    if cache_root is not None or index_id is not None:
+        return resolve_daemon_identity(project, cache_root=cache_root, index_id=index_id)
+    return resolve_daemon_identity(project)
+
+
+def _get_lock_path(identity: DaemonIdentity) -> Path:
     """Get lock file path for daemon startup synchronization."""
-    hash_val = hashlib.md5(str(Path(project).resolve()).encode()).hexdigest()[:8]
-    tmp_dir = tempfile.gettempdir()
-    return Path(tmp_dir) / f"tldr-{hash_val}.lock"
+    return get_lock_path(identity)
 
 
-def _get_pid_path(project: Path) -> Path:
+def _get_pid_path(identity: DaemonIdentity) -> Path:
     """Get PID file path for daemon process tracking."""
-    hash_val = hashlib.md5(str(Path(project).resolve()).encode()).hexdigest()[:8]
-    tmp_dir = tempfile.gettempdir()
-    return Path(tmp_dir) / f"tldr-{hash_val}.pid"
+    return get_pid_path(identity)
 
 
-def _get_socket_path(project: Path) -> Path:
+def _get_socket_path(identity: DaemonIdentity) -> Path:
     """Get socket path for daemon communication."""
-    hash_val = hashlib.md5(str(Path(project).resolve()).encode()).hexdigest()[:8]
-    tmp_dir = tempfile.gettempdir()
-    return Path(tmp_dir) / f"tldr-{hash_val}.sock"
+    return get_socket_path(identity)
 
 
 def _is_process_running(pid: int) -> bool:
@@ -122,20 +140,25 @@ def _write_pid_to_locked_file(pidfile: IO, pid: int) -> None:
     pidfile.flush()
 
 
-def _is_socket_connectable(project: Path, timeout: float = 1.0) -> bool:
+def _is_socket_connectable(identity: DaemonIdentity, timeout: float = 1.0) -> bool:
     """Check if daemon socket exists and accepts connections.
 
     This is more robust than ping-based check because it doesn't
     depend on response format - just whether a daemon is listening.
     """
-    socket_path = _get_socket_path(project)
-    if not socket_path.exists():
+    addr, port = get_connection_info(identity)
+    if port is None and not Path(addr).exists():
         return False
 
     try:
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.settimeout(timeout)
-        sock.connect(str(socket_path))
+        if port is not None:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(timeout)
+            sock.connect((addr, port))
+        else:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(timeout)
+            sock.connect(addr)
         sock.close()
         return True
     except (socket.error, OSError):
@@ -143,7 +166,7 @@ def _is_socket_connectable(project: Path, timeout: float = 1.0) -> bool:
 
 
 
-def _is_daemon_alive(project: Path, retries: int = 3, delay: float = 0.1) -> bool:
+def _is_daemon_alive(identity: DaemonIdentity, retries: int = 3, delay: float = 0.1) -> bool:
     """Check if daemon is alive using file lock on PID file.
 
     This is the authoritative check - if we can't acquire the lock,
@@ -151,14 +174,14 @@ def _is_daemon_alive(project: Path, retries: int = 3, delay: float = 0.1) -> boo
     connectivity check needed (avoids race conditions with slow daemons).
 
     Args:
-        project: Project path
+        identity: Daemon identity
         retries: Number of attempts (default 3) - used for brief retries
         delay: Seconds between attempts (default 0.1)
 
     Returns:
         True if daemon is alive (lock held by another process), False otherwise
     """
-    pid_path = _get_pid_path(project)
+    pid_path = _get_pid_path(identity)
 
     for attempt in range(retries):
         # Try to acquire lock - if we can't, daemon is running
@@ -205,16 +228,16 @@ def _is_daemon_alive(project: Path, retries: int = 3, delay: float = 0.1) -> boo
     return False
 
 
-def _create_client_socket(daemon: "TLDRDaemon") -> socket.socket:
+def _create_client_socket(identity: DaemonIdentity) -> socket.socket:
     """Create appropriate client socket for platform.
 
     Args:
-        daemon: TLDRDaemon instance to get connection info from
+        identity: Daemon identity to get connection info from
 
     Returns:
         Connected socket ready for communication
     """
-    addr, port = daemon._get_connection_info()
+    addr, port = get_connection_info(identity)
 
     if port is not None:
         # TCP socket for Windows
@@ -228,7 +251,31 @@ def _create_client_socket(daemon: "TLDRDaemon") -> socket.socket:
     return client
 
 
-def start_daemon(project_path: str | Path, foreground: bool = False):
+def _ensure_index_ignore_file(index_ctx: IndexContext) -> None:
+    cfg = index_ctx.config
+    if cfg is None or cfg.no_ignore:
+        return
+    ignore_path = cfg.ignore_file
+    if ignore_path.exists():
+        return
+    try:
+        ignore_path.resolve().relative_to(cfg.cache_root.resolve())
+    except ValueError:
+        raise ValueError(
+            f"Ignore file does not exist: {ignore_path}. Create it manually or choose a path under cache-root."
+        )
+    from ..tldrignore import ensure_tldrignore
+    created, msg = ensure_tldrignore(index_ctx.paths.index_dir, ignore_file=ignore_path)
+    if created:
+        print(msg)
+
+
+def start_daemon(
+    project_path: str | Path,
+    foreground: bool = False,
+    *,
+    index_ctx: IndexContext | None = None,
+):
     """
     Start the TLDR daemon for a project.
 
@@ -240,10 +287,9 @@ def start_daemon(project_path: str | Path, foreground: bool = False):
         foreground: If True, run in foreground; otherwise daemonize
     """
     from .core import TLDRDaemon
-    from ..tldrignore import ensure_tldrignore
-
     project = Path(project_path).resolve()
-    pid_path = _get_pid_path(project)
+    identity = _resolve_identity(project, index_ctx=index_ctx)
+    pid_path = _get_pid_path(identity)
 
     # Try to acquire exclusive lock on PID file
     # If we can't, another daemon is running
@@ -253,12 +299,16 @@ def start_daemon(project_path: str | Path, foreground: bool = False):
         return
 
     # We have the lock - we're the only one starting a daemon
-    # Ensure .tldrignore exists (create with defaults if not)
-    created, message = ensure_tldrignore(project)
-    if created:
-        print(f"\n\033[33m{message}\033[0m\n")  # Yellow warning
+    if index_ctx is None:
+        from ..tldrignore import ensure_tldrignore
+        # Ensure .tldrignore exists (create with defaults if not)
+        created, message = ensure_tldrignore(project)
+        if created:
+            print(f"\n\033[33m{message}\033[0m\n")  # Yellow warning
+    else:
+        _ensure_index_ignore_file(index_ctx)
 
-    daemon = TLDRDaemon(project)
+    daemon = TLDRDaemon(project, index_ctx=index_ctx)
 
     if foreground:
         # Write PID and run - pidfile stays open (lock held)
@@ -277,7 +327,7 @@ def start_daemon(project_path: str | Path, foreground: bool = False):
             pidfile.close()
 
             # Acquire lock to prevent race conditions
-            lock_path = _get_lock_path(project)
+            lock_path = _get_lock_path(identity)
             # Ensure lock file exists
             if not lock_path.exists():
                 lock_path.touch()
@@ -301,20 +351,35 @@ def start_daemon(project_path: str | Path, foreground: bool = False):
                     
                     try:
                         # Re-check if daemon is alive (race condition handling)
-                        if _is_daemon_alive(project):
+                        if _is_daemon_alive(identity):
                             print("Daemon already running")
                             return
 
                         # Get the connection info for display
-                        addr, port = daemon._get_connection_info()
+                        addr, port = get_connection_info(identity)
 
                         # Start detached process on Windows
                         startupinfo = subprocess.STARTUPINFO()
                         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
                         startupinfo.wShowWindow = subprocess.SW_HIDE
 
+                        cmd = [sys.executable, "-m", "tldr.daemon", str(project), "--foreground"]
+                        if index_ctx is not None and index_ctx.config is not None:
+                            cfg = index_ctx.config
+                            cmd.extend(["--cache-root", str(cfg.cache_root)])
+                            cmd.extend(["--index", str(cfg.index_id)])
+                            if cfg.ignore_file is not None:
+                                cmd.extend(["--ignore-file", str(cfg.ignore_file)])
+                            if cfg.no_ignore:
+                                cmd.append("--no-ignore")
+                            elif cfg.use_gitignore is False:
+                                cmd.append("--no-gitignore")
+                            if cfg.cli_patterns:
+                                for pattern in cfg.cli_patterns:
+                                    cmd.extend(["--ignore", pattern])
+
                         proc = subprocess.Popen(
-                            [sys.executable, "-m", "tldr.daemon", str(project), "--foreground"],
+                            cmd,
                             startupinfo=startupinfo,
                             creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NO_WINDOW,
                             stdout=subprocess.DEVNULL,
@@ -373,9 +438,9 @@ def start_daemon(project_path: str | Path, foreground: bool = False):
                 # Wait for daemon to be ready (socket exists)
                 start_time = time.time()
                 timeout = 10.0
-                socket_path = _get_socket_path(project)
+                socket_path = _get_socket_path(identity)
                 while time.time() - start_time < timeout:
-                    if socket_path.exists() and _is_socket_connectable(project, timeout=0.5):
+                    if socket_path.exists() and _is_socket_connectable(identity, timeout=0.5):
                         print(f"Daemon started with PID {pid}")
                         print(f"Socket: {daemon.socket_path}")
                         return
@@ -386,7 +451,13 @@ def start_daemon(project_path: str | Path, foreground: bool = False):
                 print(f"Socket: {daemon.socket_path}")
 
 
-def stop_daemon(project_path: str | Path) -> bool:
+def stop_daemon(
+    project_path: str | Path,
+    *,
+    index_ctx: IndexContext | None = None,
+    cache_root: Path | None = None,
+    index_id: str | None = None,
+) -> bool:
     """
     Stop the TLDR daemon for a project.
 
@@ -396,13 +467,16 @@ def stop_daemon(project_path: str | Path) -> bool:
     Returns:
         True if daemon was stopped, False if not running
     """
-    from .core import TLDRDaemon
-
     project = Path(project_path).resolve()
-    daemon = TLDRDaemon(project)
+    identity = _resolve_identity(
+        project,
+        index_ctx=index_ctx,
+        cache_root=cache_root,
+        index_id=index_id,
+    )
 
     try:
-        client = _create_client_socket(daemon)
+        client = _create_client_socket(identity)
         client.sendall(json.dumps({"cmd": "shutdown"}).encode() + b"\n")
         response = client.recv(4096)
         client.close()
@@ -411,7 +485,14 @@ def stop_daemon(project_path: str | Path) -> bool:
         return False
 
 
-def query_daemon(project_path: str | Path, command: dict) -> dict:
+def query_daemon(
+    project_path: str | Path,
+    command: dict,
+    *,
+    index_ctx: IndexContext | None = None,
+    cache_root: Path | None = None,
+    index_id: str | None = None,
+) -> dict:
     """
     Send a command to the daemon and get the response.
 
@@ -422,12 +503,14 @@ def query_daemon(project_path: str | Path, command: dict) -> dict:
     Returns:
         Response dict from daemon
     """
-    from .core import TLDRDaemon
-
     project = Path(project_path).resolve()
-    daemon = TLDRDaemon(project)
-
-    client = _create_client_socket(daemon)
+    identity = _resolve_identity(
+        project,
+        index_ctx=index_ctx,
+        cache_root=cache_root,
+        index_id=index_id,
+    )
+    client = _create_client_socket(identity)
     try:
         client.sendall(json.dumps(command).encode() + b"\n")
         response = client.recv(65536)
@@ -442,6 +525,28 @@ def main():
 
     parser = argparse.ArgumentParser(description="TLDR Daemon")
     parser.add_argument("project", help="Project path")
+    parser.add_argument("--scan-root", help="Scan root (overrides project)")
+    parser.add_argument("--cache-root", help="Directory where .tldr caches live (enables index mode)")
+    parser.add_argument("--index", dest="index_id", help="Logical index id (namespaces caches under cache-root)")
+    parser.add_argument("--ignore-file", help="Path to a .tldrignore file (index-scoped in index mode)")
+    gitignore_group = parser.add_mutually_exclusive_group()
+    gitignore_group.add_argument(
+        "--use-gitignore",
+        dest="use_gitignore",
+        action="store_true",
+        default=None,
+        help="Use .gitignore (default)",
+    )
+    gitignore_group.add_argument(
+        "--no-gitignore",
+        dest="use_gitignore",
+        action="store_false",
+        help="Ignore .gitignore",
+    )
+    parser.add_argument("--ignore", action="append", default=None, help="Additional ignore patterns")
+    parser.add_argument("--no-ignore", action="store_true", help="Bypass all ignore rules")
+    parser.add_argument("--force-rebind", action="store_true", help="Rebind index to a new scan root")
+    parser.add_argument("--rebuild", action="store_true", help="Rebuild index artifacts")
     parser.add_argument("--foreground", "-f", action="store_true", help="Run in foreground")
     parser.add_argument("--stop", action="store_true", help="Stop the daemon")
     parser.add_argument("--status", action="store_true", help="Get daemon status")
@@ -453,19 +558,63 @@ def main():
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 
+    # Env defaults (match CLI behavior)
+    if args.cache_root is None:
+        args.cache_root = os.environ.get("TLDR_CACHE_ROOT")
+    if args.index_id is None:
+        args.index_id = os.environ.get("TLDR_INDEX")
+    if args.scan_root is None:
+        args.scan_root = os.environ.get("TLDR_SCAN_ROOT")
+    if args.ignore_file is None:
+        args.ignore_file = os.environ.get("TLDR_IGNORE_FILE")
+    if args.use_gitignore is None and "TLDR_USE_GITIGNORE" in os.environ:
+        args.use_gitignore = os.environ.get("TLDR_USE_GITIGNORE") == "1"
+
+    scan_root = args.scan_root or args.project
+    if args.scan_root and Path(args.project).resolve() != Path(args.scan_root).resolve():
+        print("Error: --scan-root conflicts with positional project path", file=sys.stderr)
+        sys.exit(1)
+
+    if args.index_id and not args.cache_root:
+        print("Error: --index requires --cache-root", file=sys.stderr)
+        sys.exit(1)
+
+    index_ctx = None
+    if args.cache_root:
+        try:
+            index_ctx = get_index_context(
+                scan_root=Path(scan_root),
+                cache_root_arg=args.cache_root,
+                index_id_arg=args.index_id,
+                allow_create=not (args.stop or args.status),
+                force_rebind=args.force_rebind,
+                ignore_file_arg=args.ignore_file,
+                use_gitignore_arg=args.use_gitignore,
+                cli_patterns_arg=args.ignore,
+                no_ignore_arg=args.no_ignore,
+            )
+        except FileNotFoundError:
+            index_ctx = None
+
     if args.stop:
-        if stop_daemon(args.project):
+        if stop_daemon(scan_root, index_ctx=index_ctx, cache_root=args.cache_root, index_id=args.index_id):
             print("Daemon stopped")
         else:
             print("Daemon not running")
     elif args.status:
         try:
-            result = query_daemon(args.project, {"cmd": "status"})
+            result = query_daemon(
+                scan_root,
+                {"cmd": "status"},
+                index_ctx=index_ctx,
+                cache_root=args.cache_root,
+                index_id=args.index_id,
+            )
             print(json.dumps(result, indent=2))
         except Exception as e:
             print(f"Daemon not running: {e}")
     else:
-        start_daemon(args.project, foreground=args.foreground)
+        start_daemon(scan_root, foreground=args.foreground, index_ctx=index_ctx)
 
 
 if __name__ == "__main__":

--- a/tldr/daemon/startup.py
+++ b/tldr/daemon/startup.py
@@ -14,7 +14,7 @@ import sys
 import time
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, IO
+from typing import Optional, IO
 
 from tldr.indexing import IndexContext, get_index_context
 
@@ -33,9 +33,6 @@ if sys.platform == "win32":
     import msvcrt
 else:
     import fcntl
-
-if TYPE_CHECKING:
-    from .core import TLDRDaemon
 
 logger = logging.getLogger(__name__)
 
@@ -226,6 +223,11 @@ def _is_daemon_alive(identity: DaemonIdentity, retries: int = 3, delay: float = 
             time.sleep(delay)
 
     return False
+
+
+def is_daemon_alive(identity: DaemonIdentity) -> bool:
+    """Public wrapper for daemon liveness checks."""
+    return _is_daemon_alive(identity)
 
 
 def _create_client_socket(identity: DaemonIdentity) -> socket.socket:
@@ -478,7 +480,7 @@ def stop_daemon(
     try:
         client = _create_client_socket(identity)
         client.sendall(json.dumps({"cmd": "shutdown"}).encode() + b"\n")
-        response = client.recv(4096)
+        client.recv(4096)
         client.close()
         return True
     except (ConnectionRefusedError, FileNotFoundError, OSError):

--- a/tldr/dedup.py
+++ b/tldr/dedup.py
@@ -30,6 +30,7 @@ class ContentHashedIndex:
     """
 
     project_root: str
+    cache_dir: Path | None = None
 
     # {content_hash: list of Edge tuples}
     _by_hash: Dict[str, List[tuple]] = field(default_factory=dict)
@@ -117,7 +118,7 @@ class ContentHashedIndex:
 
     def save(self) -> None:
         """Persist index to disk."""
-        cache_dir = Path(self.project_root) / ".tldr" / "cache"
+        cache_dir = self._resolve_cache_dir()
         cache_dir.mkdir(parents=True, exist_ok=True)
 
         index_file = cache_dir / "content_index.json"
@@ -149,7 +150,7 @@ class ContentHashedIndex:
         Returns:
             True if loaded successfully, False otherwise
         """
-        cache_dir = Path(self.project_root) / ".tldr" / "cache"
+        cache_dir = self._resolve_cache_dir()
         index_file = cache_dir / "content_index.json"
 
         if not index_file.exists():
@@ -175,6 +176,11 @@ class ContentHashedIndex:
         self._cache_hits = stats.get("cache_hits", 0)
 
         return True
+
+    def _resolve_cache_dir(self) -> Path:
+        if self.cache_dir is not None:
+            return self.cache_dir
+        return Path(self.project_root) / ".tldr" / "cache"
 
     def _edges_from_tuples(self, tuples: List[tuple]) -> List[Edge]:
         """Convert edge tuples back to Edge objects."""

--- a/tldr/dedup.py
+++ b/tldr/dedup.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional
 
 from tldr.patch import compute_file_hash, extract_edges_from_file, Edge
 

--- a/tldr/dirty_flag.py
+++ b/tldr/dirty_flag.py
@@ -29,8 +29,13 @@ from typing import List, Union
 DIRTY_FILE = ".tldr/cache/dirty.json"
 
 
-def _get_dirty_path(project_path: Union[str, Path]) -> Path:
+def _get_dirty_path(
+    project_path: Union[str, Path],
+    dirty_path: Union[str, Path, None] = None,
+) -> Path:
     """Get the full path to the dirty flag file."""
+    if dirty_path is not None:
+        return Path(dirty_path)
     return Path(project_path) / DIRTY_FILE
 
 
@@ -47,7 +52,11 @@ def _get_timestamp() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-def mark_dirty(project_path: Union[str, Path], edited_file: str) -> None:
+def mark_dirty(
+    project_path: Union[str, Path],
+    edited_file: str,
+    dirty_path: Union[str, Path, None] = None,
+) -> None:
     """Mark a file as dirty (needing cache rebuild).
 
     Creates or updates the dirty flag file with the edited file path.
@@ -57,7 +66,7 @@ def mark_dirty(project_path: Union[str, Path], edited_file: str) -> None:
         project_path: Root directory of the project
         edited_file: Relative path to the edited file
     """
-    dirty_path = _get_dirty_path(project_path)
+    dirty_path = _get_dirty_path(project_path, dirty_path)
     normalized_file = _normalize_file_path(edited_file)
     now = _get_timestamp()
 
@@ -91,7 +100,10 @@ def mark_dirty(project_path: Union[str, Path], edited_file: str) -> None:
     dirty_path.write_text(json.dumps(data, indent=2))
 
 
-def is_dirty(project_path: Union[str, Path]) -> bool:
+def is_dirty(
+    project_path: Union[str, Path],
+    dirty_path: Union[str, Path, None] = None,
+) -> bool:
     """Check if the project has dirty files needing rebuild.
 
     Args:
@@ -100,11 +112,14 @@ def is_dirty(project_path: Union[str, Path]) -> bool:
     Returns:
         True if dirty flag file exists, False otherwise
     """
-    dirty_path = _get_dirty_path(project_path)
+    dirty_path = _get_dirty_path(project_path, dirty_path)
     return dirty_path.exists()
 
 
-def get_dirty_files(project_path: Union[str, Path]) -> List[str]:
+def get_dirty_files(
+    project_path: Union[str, Path],
+    dirty_path: Union[str, Path, None] = None,
+) -> List[str]:
     """Get the list of dirty files.
 
     Args:
@@ -114,7 +129,7 @@ def get_dirty_files(project_path: Union[str, Path]) -> List[str]:
         List of file paths that were edited since last rebuild.
         Empty list if no dirty flag exists.
     """
-    dirty_path = _get_dirty_path(project_path)
+    dirty_path = _get_dirty_path(project_path, dirty_path)
 
     if not dirty_path.exists():
         return []
@@ -126,7 +141,10 @@ def get_dirty_files(project_path: Union[str, Path]) -> List[str]:
         return []
 
 
-def get_dirty_count(project_path: Union[str, Path]) -> int:
+def get_dirty_count(
+    project_path: Union[str, Path],
+    dirty_path: Union[str, Path, None] = None,
+) -> int:
     """Get the count of dirty files.
 
     Useful for threshold-based decisions (e.g., full rebuild vs incremental).
@@ -137,10 +155,13 @@ def get_dirty_count(project_path: Union[str, Path]) -> int:
     Returns:
         Number of dirty files, or 0 if no dirty flag exists.
     """
-    return len(get_dirty_files(project_path))
+    return len(get_dirty_files(project_path, dirty_path))
 
 
-def clear_dirty(project_path: Union[str, Path]) -> None:
+def clear_dirty(
+    project_path: Union[str, Path],
+    dirty_path: Union[str, Path, None] = None,
+) -> None:
     """Clear the dirty flag (after rebuild).
 
     Removes the dirty flag file. Safe to call even if file doesn't exist.
@@ -148,7 +169,7 @@ def clear_dirty(project_path: Union[str, Path]) -> None:
     Args:
         project_path: Root directory of the project
     """
-    dirty_path = _get_dirty_path(project_path)
+    dirty_path = _get_dirty_path(project_path, dirty_path)
 
     try:
         dirty_path.unlink(missing_ok=True)

--- a/tldr/hybrid_extractor.py
+++ b/tldr/hybrid_extractor.py
@@ -414,11 +414,8 @@ class HybridExtractor:
                         names.add(self._safe_decode(source[c.start_byte:c.end_byte]))
                         break
             elif child.type == "class_declaration":
-                class_name = ""
                 for c in child.children:
-                    if c.type in ("identifier", "type_identifier"):
-                        class_name = self._safe_decode(source[c.start_byte:c.end_byte])
-                    elif c.type == "class_body":
+                    if c.type == "class_body":
                         for method in c.children:
                             if method.type == "method_definition":
                                 for m in method.children:
@@ -1210,7 +1207,6 @@ class HybridExtractor:
         if defined_names is None:
             defined_names = set()
         impl_type = ""
-        trait_name = ""
 
         for child in node.children:
             if child.type == "type_identifier":
@@ -2177,11 +2173,9 @@ class HybridExtractor:
         if text.startswith("import "):
             module = text[7:].strip()
             # Handle alias: import foo.bar as baz
-            alias = None
             if " as " in module:
                 parts = module.split(" as ")
                 module = parts[0].strip()
-                alias = parts[1].strip()
             return ImportInfo(
                 module=module,
                 names=[],

--- a/tldr/incremental_parse.py
+++ b/tldr/incremental_parse.py
@@ -12,8 +12,7 @@ Key components:
 import hashlib
 import json
 import logging
-import pickle
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
@@ -26,7 +25,7 @@ TREE_SITTER_GO_AVAILABLE = False
 TREE_SITTER_RUST_AVAILABLE = False
 
 try:
-    from tree_sitter import Language, Parser, Tree
+    from tree_sitter import Language, Parser
     import tree_sitter_typescript
     import tree_sitter_javascript
     TREE_SITTER_AVAILABLE = True

--- a/tldr/indexing/__init__.py
+++ b/tldr/indexing/__init__.py
@@ -1,0 +1,23 @@
+from .index import (
+    IndexConfig,
+    IndexContext,
+    IndexPaths,
+    compute_index_key,
+    derive_index_id,
+    ensure_index,
+    get_index_context,
+    load_meta,
+    update_meta_semantic,
+)
+
+__all__ = [
+    "IndexConfig",
+    "IndexContext",
+    "IndexPaths",
+    "compute_index_key",
+    "derive_index_id",
+    "ensure_index",
+    "get_index_context",
+    "load_meta",
+    "update_meta_semantic",
+]

--- a/tldr/indexing/index.py
+++ b/tldr/indexing/index.py
@@ -389,7 +389,8 @@ def get_index_context(
         cli_patterns_arg = _UNSET
     if no_ignore_arg is None:
         no_ignore_arg = _UNSET
-    if cache_root_arg is None or str(cache_root_arg).strip() == "":
+    cache_root_value = None if cache_root_arg is None else str(cache_root_arg).strip()
+    if cache_root_value is None or cache_root_value == "":
         return IndexContext(
             mode="legacy",
             scan_root=scan_root,
@@ -400,7 +401,17 @@ def get_index_context(
             config=None,
         )
 
-    cache_root = Path(cache_root_arg).resolve()
+    if cache_root_value.lower() == "git":
+        from tldr.tldrignore import resolve_git_root
+
+        git_root = resolve_git_root(scan_root)
+        if git_root is None:
+            git_root = resolve_git_root(Path.cwd())
+        if git_root is None:
+            raise ValueError("cache_root 'git' requested but no git repository found")
+        cache_root = git_root
+    else:
+        cache_root = Path(cache_root_arg).resolve()
     if index_id_arg is None or index_id_arg == "":
         index_id = derive_index_id(scan_root, cache_root)
     else:

--- a/tldr/indexing/index.py
+++ b/tldr/indexing/index.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class IndexConfig:
+    cache_root: Path
+    scan_root: Path
+    index_id: str
+    index_key: str
+
+
+@dataclass(frozen=True)
+class IndexPaths:
+    tldr_dir: Path
+    indexes_dir: Path
+    index_dir: Path
+    meta: Path
+    cache_dir: Path
+    call_graph: Path
+    languages: Path
+    dirty: Path
+    semantic_dir: Path
+    semantic_faiss: Path
+    semantic_metadata: Path
+
+    @classmethod
+    def from_config(cls, config: IndexConfig) -> "IndexPaths":
+        tldr_dir = config.cache_root / ".tldr"
+        indexes_dir = tldr_dir / "indexes"
+        index_dir = indexes_dir / config.index_key
+        meta = index_dir / "meta.json"
+        cache_dir = index_dir / "cache"
+        semantic_dir = cache_dir / "semantic"
+        return cls(
+            tldr_dir=tldr_dir,
+            indexes_dir=indexes_dir,
+            index_dir=index_dir,
+            meta=meta,
+            cache_dir=cache_dir,
+            call_graph=cache_dir / "call_graph.json",
+            languages=index_dir / "languages.json",
+            dirty=cache_dir / "dirty.json",
+            semantic_dir=semantic_dir,
+            semantic_faiss=semantic_dir / "index.faiss",
+            semantic_metadata=semantic_dir / "metadata.json",
+        )
+
+
+@dataclass(frozen=True)
+class IndexContext:
+    mode: Literal["legacy", "index"]
+    scan_root: Path
+    cache_root: Path | None
+    index_id: str | None
+    index_key: str | None
+    paths: IndexPaths | None
+    config: IndexConfig | None
+
+
+def compute_index_key(index_id: str) -> str:
+    digest = hashlib.sha256(index_id.encode("utf-8")).digest()
+    encoded = base64.b32encode(digest).decode("ascii").lower().rstrip("=")
+    return encoded[:20]
+
+
+def derive_index_id(scan_root: Path, cache_root: Path) -> str:
+    scan_root = scan_root.resolve()
+    cache_root = cache_root.resolve()
+    try:
+        rel = scan_root.relative_to(cache_root)
+        return f"path:{rel.as_posix()}"
+    except ValueError:
+        return f"abs:{scan_root}"
+
+
+def _normalize_abs(path: Path) -> str:
+    return os.path.normcase(str(path.resolve()))
+
+
+def _scan_root_rel(scan_root: Path, cache_root: Path) -> str | None:
+    try:
+        rel = scan_root.resolve().relative_to(cache_root.resolve())
+        return rel.as_posix()
+    except ValueError:
+        return None
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _create_meta(config: IndexConfig) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "index_id": config.index_id,
+        "index_key": config.index_key,
+        "scan_root_abs": _normalize_abs(config.scan_root),
+        "scan_root_rel_to_cache_root": _scan_root_rel(config.scan_root, config.cache_root),
+        "cache_root_abs": _normalize_abs(config.cache_root),
+        "created_at": _now_iso(),
+        "last_used_at": _now_iso(),
+    }
+
+
+def load_meta(paths: IndexPaths) -> dict | None:
+    if not paths.meta.exists():
+        return None
+    try:
+        return json.loads(paths.meta.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _write_meta(paths: IndexPaths, meta: dict) -> None:
+    paths.index_dir.mkdir(parents=True, exist_ok=True)
+    paths.meta.write_text(json.dumps(meta, indent=2))
+
+
+def _validate_meta(meta: dict, config: IndexConfig) -> None:
+    if meta.get("index_id") != config.index_id:
+        raise ValueError("Index ID mismatch for existing index directory.")
+
+    # Compare scan root (prefer relative if available and applicable)
+    rel = meta.get("scan_root_rel_to_cache_root")
+    if rel:
+        current_rel = _scan_root_rel(config.scan_root, config.cache_root)
+        if current_rel and rel != current_rel:
+            raise ValueError("Scan root mismatch for existing index directory.")
+        if current_rel is None:
+            # Fall back to absolute comparison if current scan_root isn't under cache_root
+            if meta.get("scan_root_abs") != _normalize_abs(config.scan_root):
+                raise ValueError("Scan root mismatch for existing index directory.")
+        return
+
+    if meta.get("scan_root_abs") != _normalize_abs(config.scan_root):
+        raise ValueError("Scan root mismatch for existing index directory.")
+
+
+def ensure_index(
+    config: IndexConfig,
+    *,
+    allow_create: bool,
+    force_rebind: bool = False,
+) -> tuple[IndexPaths, dict]:
+    paths = IndexPaths.from_config(config)
+    meta = load_meta(paths)
+
+    if meta is not None:
+        try:
+            _validate_meta(meta, config)
+        except ValueError:
+            if not force_rebind:
+                raise
+            if paths.index_dir.exists():
+                shutil.rmtree(paths.index_dir)
+            meta = None
+
+    if meta is None:
+        if not allow_create:
+            raise FileNotFoundError(
+                f"Index not initialized for {config.index_id}. Run warm or semantic index first."
+            )
+        meta = _create_meta(config)
+        _write_meta(paths, meta)
+
+    return paths, meta
+
+
+def update_meta_semantic(
+    paths: IndexPaths,
+    config: IndexConfig,
+    *,
+    model: str,
+    dim: int,
+    lang: str | None = None,
+) -> None:
+    meta = load_meta(paths) or _create_meta(config)
+    meta["semantic"] = {
+        "model": model,
+        "dim": dim,
+        "lang": lang,
+    }
+    meta["last_used_at"] = _now_iso()
+    _write_meta(paths, meta)
+
+
+def get_index_context(
+    *,
+    scan_root: Path,
+    cache_root_arg: str | Path | None,
+    index_id_arg: str | None,
+    allow_create: bool,
+    force_rebind: bool = False,
+) -> IndexContext:
+    if cache_root_arg is None or str(cache_root_arg).strip() == "":
+        return IndexContext(
+            mode="legacy",
+            scan_root=scan_root,
+            cache_root=None,
+            index_id=None,
+            index_key=None,
+            paths=None,
+            config=None,
+        )
+
+    cache_root = Path(cache_root_arg).resolve()
+    if index_id_arg is None or index_id_arg == "":
+        index_id = derive_index_id(scan_root, cache_root)
+    else:
+        index_id = index_id_arg
+
+    index_key = compute_index_key(index_id)
+    config = IndexConfig(
+        cache_root=cache_root,
+        scan_root=scan_root.resolve(),
+        index_id=index_id,
+        index_key=index_key,
+    )
+    paths, _ = ensure_index(
+        config, allow_create=allow_create, force_rebind=force_rebind
+    )
+    return IndexContext(
+        mode="index",
+        scan_root=config.scan_root,
+        cache_root=config.cache_root,
+        index_id=config.index_id,
+        index_key=config.index_key,
+        paths=paths,
+        config=config,
+    )

--- a/tldr/indexing/index.py
+++ b/tldr/indexing/index.py
@@ -12,6 +12,8 @@ from typing import Literal
 
 SCHEMA_VERSION = 1
 
+_UNSET = object()
+
 
 @dataclass(frozen=True)
 class IndexConfig:
@@ -19,6 +21,11 @@ class IndexConfig:
     scan_root: Path
     index_id: str
     index_key: str
+    ignore_file: Path
+    use_gitignore: bool
+    gitignore_root: Path | None
+    cli_patterns: tuple[str, ...] | None
+    no_ignore: bool
 
 
 @dataclass(frozen=True)
@@ -27,6 +34,7 @@ class IndexPaths:
     indexes_dir: Path
     index_dir: Path
     meta: Path
+    ignore_file: Path
     cache_dir: Path
     call_graph: Path
     languages: Path
@@ -41,6 +49,7 @@ class IndexPaths:
         indexes_dir = tldr_dir / "indexes"
         index_dir = indexes_dir / config.index_key
         meta = index_dir / "meta.json"
+        ignore_file = config.ignore_file
         cache_dir = index_dir / "cache"
         semantic_dir = cache_dir / "semantic"
         return cls(
@@ -48,6 +57,38 @@ class IndexPaths:
             indexes_dir=indexes_dir,
             index_dir=index_dir,
             meta=meta,
+            ignore_file=ignore_file,
+            cache_dir=cache_dir,
+            call_graph=cache_dir / "call_graph.json",
+            languages=index_dir / "languages.json",
+            dirty=cache_dir / "dirty.json",
+            semantic_dir=semantic_dir,
+            semantic_faiss=semantic_dir / "index.faiss",
+            semantic_metadata=semantic_dir / "metadata.json",
+        )
+
+    @classmethod
+    def from_parts(
+        cls,
+        cache_root: Path,
+        index_key: str,
+        *,
+        ignore_file: Path | None = None,
+    ) -> "IndexPaths":
+        tldr_dir = cache_root / ".tldr"
+        indexes_dir = tldr_dir / "indexes"
+        index_dir = indexes_dir / index_key
+        meta = index_dir / "meta.json"
+        if ignore_file is None:
+            ignore_file = index_dir / ".tldrignore"
+        cache_dir = index_dir / "cache"
+        semantic_dir = cache_dir / "semantic"
+        return cls(
+            tldr_dir=tldr_dir,
+            indexes_dir=indexes_dir,
+            index_dir=index_dir,
+            meta=meta,
+            ignore_file=ignore_file,
             cache_dir=cache_dir,
             call_graph=cache_dir / "call_graph.json",
             languages=index_dir / "languages.json",
@@ -97,11 +138,28 @@ def _scan_root_rel(scan_root: Path, cache_root: Path) -> str | None:
         return None
 
 
+def _path_rel(path: Path | None, cache_root: Path) -> str | None:
+    if path is None:
+        return None
+    try:
+        rel = path.resolve().relative_to(cache_root.resolve())
+        return rel.as_posix()
+    except ValueError:
+        return None
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _create_meta(config: IndexConfig) -> dict:
+    from tldr.tldrignore import compute_ignore_hash
+
+    content_hash = (
+        compute_ignore_hash(config.ignore_file)
+        if not config.no_ignore
+        else "no-ignore"
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "index_id": config.index_id,
@@ -109,6 +167,17 @@ def _create_meta(config: IndexConfig) -> dict:
         "scan_root_abs": _normalize_abs(config.scan_root),
         "scan_root_rel_to_cache_root": _scan_root_rel(config.scan_root, config.cache_root),
         "cache_root_abs": _normalize_abs(config.cache_root),
+        "ignore": {
+            "file_abs": _normalize_abs(config.ignore_file),
+            "file_rel_to_cache_root": _path_rel(config.ignore_file, config.cache_root),
+            "use_gitignore": bool(config.use_gitignore),
+            "gitignore_root_abs": _normalize_abs(config.gitignore_root) if config.gitignore_root else None,
+            "gitignore_root_rel_to_cache_root": _path_rel(config.gitignore_root, config.cache_root),
+            "cli_patterns": list(config.cli_patterns or ()),
+            "no_ignore": bool(config.no_ignore),
+            "content_hash": content_hash,
+            "last_changed_at": _now_iso(),
+        },
         "created_at": _now_iso(),
         "last_used_at": _now_iso(),
     }
@@ -147,6 +216,24 @@ def _validate_meta(meta: dict, config: IndexConfig) -> None:
     if meta.get("scan_root_abs") != _normalize_abs(config.scan_root):
         raise ValueError("Scan root mismatch for existing index directory.")
 
+    ignore_meta = meta.get("ignore")
+    if ignore_meta:
+        if ignore_meta.get("file_abs") != _normalize_abs(config.ignore_file):
+            raise ValueError("Ignore file mismatch for existing index directory.")
+        if bool(ignore_meta.get("use_gitignore", True)) != bool(config.use_gitignore):
+            raise ValueError("Gitignore usage mismatch for existing index directory.")
+        if bool(ignore_meta.get("no_ignore", False)) != bool(config.no_ignore):
+            raise ValueError("Ignore toggle mismatch for existing index directory.")
+        meta_patterns = ignore_meta.get("cli_patterns") or []
+        config_patterns = list(config.cli_patterns or ())
+        if meta_patterns != config_patterns:
+            raise ValueError("Ignore patterns mismatch for existing index directory.")
+        if config.use_gitignore:
+            meta_root = ignore_meta.get("gitignore_root_abs")
+            config_root = _normalize_abs(config.gitignore_root) if config.gitignore_root else None
+            if meta_root and config_root and meta_root != config_root:
+                raise ValueError("Gitignore root mismatch for existing index directory.")
+
 
 def ensure_index(
     config: IndexConfig,
@@ -174,8 +261,67 @@ def ensure_index(
             )
         meta = _create_meta(config)
         _write_meta(paths, meta)
+    else:
+        meta_changed, ignore_changed = _sync_ignore_meta(meta, config)
+        if meta_changed:
+            _write_meta(paths, meta)
+        if ignore_changed:
+            _invalidate_index_caches(paths)
 
     return paths, meta
+
+
+def _sync_ignore_meta(meta: dict, config: IndexConfig) -> tuple[bool, bool]:
+    from tldr.tldrignore import compute_ignore_hash
+
+    ignore_meta = meta.get("ignore")
+    ignore_changed = False
+    meta_changed = False
+
+    expected_hash = (
+        compute_ignore_hash(config.ignore_file)
+        if not config.no_ignore
+        else "no-ignore"
+    )
+
+    if not ignore_meta:
+        meta["ignore"] = {
+            "file_abs": _normalize_abs(config.ignore_file),
+            "file_rel_to_cache_root": _path_rel(config.ignore_file, config.cache_root),
+            "use_gitignore": bool(config.use_gitignore),
+            "gitignore_root_abs": _normalize_abs(config.gitignore_root) if config.gitignore_root else None,
+            "gitignore_root_rel_to_cache_root": _path_rel(config.gitignore_root, config.cache_root),
+            "cli_patterns": list(config.cli_patterns or ()),
+            "no_ignore": bool(config.no_ignore),
+            "content_hash": expected_hash,
+            "last_changed_at": _now_iso(),
+        }
+        meta_changed = True
+        ignore_changed = True
+        return meta_changed, ignore_changed
+
+    if ignore_meta.get("content_hash") != expected_hash:
+        ignore_meta["content_hash"] = expected_hash
+        ignore_meta["last_changed_at"] = _now_iso()
+        meta_changed = True
+        ignore_changed = True
+
+    meta["ignore"] = ignore_meta
+    return meta_changed, ignore_changed
+
+
+def _invalidate_index_caches(paths: IndexPaths) -> None:
+    for path in [
+        paths.call_graph,
+        paths.languages,
+        paths.dirty,
+        paths.semantic_faiss,
+        paths.semantic_metadata,
+    ]:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def update_meta_semantic(
@@ -203,7 +349,19 @@ def get_index_context(
     index_id_arg: str | None,
     allow_create: bool,
     force_rebind: bool = False,
+    ignore_file_arg: str | Path | None | object = _UNSET,
+    use_gitignore_arg: bool | object | None = _UNSET,
+    cli_patterns_arg: list[str] | None | object = _UNSET,
+    no_ignore_arg: bool | object | None = _UNSET,
 ) -> IndexContext:
+    if ignore_file_arg is None:
+        ignore_file_arg = _UNSET
+    if use_gitignore_arg is None:
+        use_gitignore_arg = _UNSET
+    if cli_patterns_arg is None:
+        cli_patterns_arg = _UNSET
+    if no_ignore_arg is None:
+        no_ignore_arg = _UNSET
     if cache_root_arg is None or str(cache_root_arg).strip() == "":
         return IndexContext(
             mode="legacy",
@@ -222,11 +380,64 @@ def get_index_context(
         index_id = index_id_arg
 
     index_key = compute_index_key(index_id)
+
+    meta_paths = IndexPaths.from_parts(cache_root, index_key)
+    meta = load_meta(meta_paths)
+
+    ignore_meta = meta.get("ignore") if meta else None
+
+    if ignore_file_arg is _UNSET:
+        if ignore_meta:
+            rel = ignore_meta.get("file_rel_to_cache_root")
+            abs_path = ignore_meta.get("file_abs")
+            if rel:
+                ignore_file = cache_root / rel
+            elif abs_path:
+                ignore_file = Path(abs_path)
+            else:
+                ignore_file = meta_paths.ignore_file
+        else:
+            ignore_file = meta_paths.ignore_file
+    else:
+        ignore_file = Path(ignore_file_arg)
+
+    if use_gitignore_arg is _UNSET:
+        use_gitignore = bool(ignore_meta.get("use_gitignore", True)) if ignore_meta else True
+    else:
+        use_gitignore = bool(use_gitignore_arg)
+
+    if no_ignore_arg is _UNSET:
+        no_ignore = bool(ignore_meta.get("no_ignore", False)) if ignore_meta else False
+    else:
+        no_ignore = bool(no_ignore_arg)
+
+    if cli_patterns_arg is _UNSET:
+        cli_patterns = (
+            list(ignore_meta.get("cli_patterns") or []) if ignore_meta else []
+        )
+    else:
+        cli_patterns = list(cli_patterns_arg or [])
+
+    gitignore_root = None
+    if use_gitignore:
+        if ignore_meta and ignore_meta.get("gitignore_root_abs"):
+            gitignore_root = Path(ignore_meta.get("gitignore_root_abs"))
+        else:
+            from tldr.tldrignore import resolve_git_root
+            gitignore_root = resolve_git_root(cache_root)
+            if gitignore_root is None:
+                gitignore_root = cache_root
+
     config = IndexConfig(
         cache_root=cache_root,
         scan_root=scan_root.resolve(),
         index_id=index_id,
         index_key=index_key,
+        ignore_file=ignore_file.resolve(),
+        use_gitignore=use_gitignore,
+        gitignore_root=gitignore_root.resolve() if gitignore_root else None,
+        cli_patterns=tuple(cli_patterns) if cli_patterns else None,
+        no_ignore=no_ignore,
     )
     paths, _ = ensure_index(
         config, allow_create=allow_create, force_rebind=force_rebind

--- a/tldr/indexing/index.py
+++ b/tldr/indexing/index.py
@@ -31,6 +31,8 @@ class IndexConfig:
 @dataclass(frozen=True)
 class IndexPaths:
     tldr_dir: Path
+    tldr_config: Path
+    claude_settings: Path
     indexes_dir: Path
     index_dir: Path
     meta: Path
@@ -39,21 +41,31 @@ class IndexPaths:
     call_graph: Path
     languages: Path
     dirty: Path
+    file_hashes: Path
+    content_index: Path
+    stats_dir: Path
+    hook_activity: Path
     semantic_dir: Path
     semantic_faiss: Path
     semantic_metadata: Path
+    daemon_status: Path
 
     @classmethod
     def from_config(cls, config: IndexConfig) -> "IndexPaths":
         tldr_dir = config.cache_root / ".tldr"
+        tldr_config = tldr_dir / "config.json"
+        claude_settings = config.cache_root / ".claude" / "settings.json"
         indexes_dir = tldr_dir / "indexes"
         index_dir = indexes_dir / config.index_key
         meta = index_dir / "meta.json"
         ignore_file = config.ignore_file
         cache_dir = index_dir / "cache"
+        stats_dir = index_dir / "stats"
         semantic_dir = cache_dir / "semantic"
         return cls(
             tldr_dir=tldr_dir,
+            tldr_config=tldr_config,
+            claude_settings=claude_settings,
             indexes_dir=indexes_dir,
             index_dir=index_dir,
             meta=meta,
@@ -62,9 +74,14 @@ class IndexPaths:
             call_graph=cache_dir / "call_graph.json",
             languages=index_dir / "languages.json",
             dirty=cache_dir / "dirty.json",
+            file_hashes=cache_dir / "file_hashes.json",
+            content_index=cache_dir / "content_index.json",
+            stats_dir=stats_dir,
+            hook_activity=stats_dir / "hook_activity.jsonl",
             semantic_dir=semantic_dir,
             semantic_faiss=semantic_dir / "index.faiss",
             semantic_metadata=semantic_dir / "metadata.json",
+            daemon_status=index_dir / "status",
         )
 
     @classmethod
@@ -76,15 +93,20 @@ class IndexPaths:
         ignore_file: Path | None = None,
     ) -> "IndexPaths":
         tldr_dir = cache_root / ".tldr"
+        tldr_config = tldr_dir / "config.json"
+        claude_settings = cache_root / ".claude" / "settings.json"
         indexes_dir = tldr_dir / "indexes"
         index_dir = indexes_dir / index_key
         meta = index_dir / "meta.json"
         if ignore_file is None:
             ignore_file = index_dir / ".tldrignore"
         cache_dir = index_dir / "cache"
+        stats_dir = index_dir / "stats"
         semantic_dir = cache_dir / "semantic"
         return cls(
             tldr_dir=tldr_dir,
+            tldr_config=tldr_config,
+            claude_settings=claude_settings,
             indexes_dir=indexes_dir,
             index_dir=index_dir,
             meta=meta,
@@ -93,9 +115,14 @@ class IndexPaths:
             call_graph=cache_dir / "call_graph.json",
             languages=index_dir / "languages.json",
             dirty=cache_dir / "dirty.json",
+            file_hashes=cache_dir / "file_hashes.json",
+            content_index=cache_dir / "content_index.json",
+            stats_dir=stats_dir,
+            hook_activity=stats_dir / "hook_activity.jsonl",
             semantic_dir=semantic_dir,
             semantic_faiss=semantic_dir / "index.faiss",
             semantic_metadata=semantic_dir / "metadata.json",
+            daemon_status=index_dir / "status",
         )
 
 

--- a/tldr/indexing/management.py
+++ b/tldr/indexing/management.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from .index import IndexPaths
+
+
+def _iter_index_dirs(cache_root: Path) -> list[Path]:
+    indexes_dir = cache_root / ".tldr" / "indexes"
+    if not indexes_dir.exists():
+        return []
+    try:
+        entries = [p for p in indexes_dir.iterdir() if p.is_dir()]
+    except OSError:
+        return []
+    return sorted(entries, key=lambda p: p.name)
+
+
+def _read_meta(meta_path: Path) -> tuple[dict | None, str | None]:
+    if not meta_path.exists():
+        return None, "missing meta.json"
+    try:
+        return json.loads(meta_path.read_text()), None
+    except (json.JSONDecodeError, OSError):
+        return None, "invalid meta.json"
+
+
+def _dir_size_bytes(path: Path) -> int:
+    total = 0
+    for root, _, files in os.walk(path):
+        for name in files:
+            file_path = Path(root) / name
+            try:
+                if file_path.is_symlink():
+                    continue
+                total += file_path.stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def _iso_from_timestamp(timestamp: float) -> str:
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _extract_last_used(meta: dict | None, meta_path: Path, index_dir: Path) -> str | None:
+    if meta:
+        for key in ("last_used_at", "created_at"):
+            value = meta.get(key)
+            if value:
+                return value
+    for path in (meta_path, index_dir):
+        try:
+            return _iso_from_timestamp(path.stat().st_mtime)
+        except OSError:
+            continue
+    return None
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _extract_scan_root(meta: dict | None) -> str | None:
+    if not meta:
+        return None
+    return meta.get("scan_root_rel_to_cache_root") or meta.get("scan_root_abs")
+
+
+def _daemon_running(cache_root: Path, index_key: str, meta: dict | None) -> bool:
+    try:
+        from tldr.daemon.identity import get_pid_path, resolve_daemon_identity
+        from tldr.daemon.startup import is_daemon_alive
+    except Exception:
+        return False
+
+    scan_root = meta.get("scan_root_abs") if meta else None
+    if scan_root:
+        scan_root_path = Path(scan_root)
+    else:
+        scan_root_path = cache_root
+    index_id = meta.get("index_id") if meta else None
+    identity = resolve_daemon_identity(
+        scan_root_path,
+        cache_root=cache_root,
+        index_id=index_id,
+        index_key=index_key,
+    )
+    if not get_pid_path(identity).exists():
+        return False
+    return is_daemon_alive(identity)
+
+
+def _clear_port_file(cache_root: Path, index_key: str, meta: dict | None) -> None:
+    try:
+        from tldr.daemon.identity import clear_port_file, resolve_daemon_identity
+    except Exception:
+        return
+
+    scan_root = meta.get("scan_root_abs") if meta else None
+    if scan_root:
+        scan_root_path = Path(scan_root)
+    else:
+        scan_root_path = cache_root
+    index_id = meta.get("index_id") if meta else None
+    identity = resolve_daemon_identity(
+        scan_root_path,
+        cache_root=cache_root,
+        index_id=index_id,
+        index_key=index_key,
+    )
+    clear_port_file(identity)
+
+
+def list_indexes(cache_root: Path) -> dict:
+    entries: list[dict] = []
+    total_size = 0
+    for index_dir in _iter_index_dirs(cache_root):
+        meta_path = index_dir / "meta.json"
+        meta, meta_error = _read_meta(meta_path)
+        size_bytes = _dir_size_bytes(index_dir)
+        total_size += size_bytes
+        entry = {
+            "index_id": meta.get("index_id") if meta else None,
+            "index_key": meta.get("index_key") if meta else index_dir.name,
+            "scan_root": _extract_scan_root(meta),
+            "last_used_at": _extract_last_used(meta, meta_path, index_dir),
+            "size_bytes": size_bytes,
+            "index_dir": str(index_dir),
+            "meta_path": str(meta_path),
+            "meta_ok": meta is not None and meta_error is None,
+            "meta_error": meta_error,
+        }
+        entries.append(entry)
+    return {
+        "cache_root": str(cache_root),
+        "total_size_bytes": total_size,
+        "indexes": entries,
+    }
+
+
+def _resolve_index_ref(
+    cache_root: Path, index_ref: str
+) -> tuple[Path, dict | None, str | None, str]:
+    indexes_dir = cache_root / ".tldr" / "indexes"
+    if not indexes_dir.exists():
+        raise FileNotFoundError("No indexes found under cache root")
+
+    matches: list[tuple[Path, dict | None, str | None, str]] = []
+    fallback: tuple[Path, dict | None, str | None, str] | None = None
+
+    for index_dir in _iter_index_dirs(cache_root):
+        meta_path = index_dir / "meta.json"
+        meta, meta_error = _read_meta(meta_path)
+        if index_dir.name == index_ref:
+            fallback = (index_dir, meta, meta_error, "index_key")
+        if meta and meta.get("index_id") == index_ref:
+            matches.append((index_dir, meta, meta_error, "index_id"))
+
+    if matches:
+        if len(matches) > 1:
+            raise ValueError(f"Multiple indexes found for id {index_ref}")
+        return matches[0]
+    if fallback:
+        return fallback
+    raise FileNotFoundError(f"Index not found: {index_ref}")
+
+
+def _artifact_info(path: Path) -> dict:
+    info = {
+        "path": str(path),
+        "exists": False,
+        "size_bytes": None,
+        "modified_at": None,
+    }
+    try:
+        if path.exists():
+            stat = path.stat()
+            info["exists"] = True
+            info["size_bytes"] = stat.st_size
+            info["modified_at"] = _iso_from_timestamp(stat.st_mtime)
+    except OSError:
+        pass
+    return info
+
+
+def get_index_info(cache_root: Path, index_ref: str) -> dict:
+    index_dir, meta, meta_error, resolved_by = _resolve_index_ref(cache_root, index_ref)
+    if meta is None or meta_error is not None:
+        raise ValueError(
+            f"Index metadata missing or invalid for {index_ref}. Use --force with index rm to delete."
+        )
+
+    index_key = meta.get("index_key") or index_dir.name
+    ignore_file = None
+    ignore_meta = meta.get("ignore") if meta else None
+    if ignore_meta:
+        ignore_file = ignore_meta.get("file_abs")
+    ignore_path = Path(ignore_file) if ignore_file else None
+    paths = IndexPaths.from_parts(
+        cache_root, index_key, ignore_file=ignore_path
+    )
+
+    artifacts = {
+        "meta": _artifact_info(paths.meta),
+        "ignore_file": _artifact_info(paths.ignore_file),
+        "call_graph": _artifact_info(paths.call_graph),
+        "languages": _artifact_info(paths.languages),
+        "dirty": _artifact_info(paths.dirty),
+        "file_hashes": _artifact_info(paths.file_hashes),
+        "content_index": _artifact_info(paths.content_index),
+        "hook_activity": _artifact_info(paths.hook_activity),
+        "semantic_faiss": _artifact_info(paths.semantic_faiss),
+        "semantic_metadata": _artifact_info(paths.semantic_metadata),
+        "daemon_status": _artifact_info(paths.daemon_status),
+    }
+
+    return {
+        "index_id": meta.get("index_id"),
+        "index_key": index_key,
+        "scan_root": _extract_scan_root(meta),
+        "cache_root": str(cache_root),
+        "index_dir": str(index_dir),
+        "resolved_by": resolved_by,
+        "meta": meta,
+        "artifacts": artifacts,
+        "total_size_bytes": _dir_size_bytes(index_dir),
+        "daemon_running": _daemon_running(cache_root, index_key, meta),
+    }
+
+
+def remove_index(cache_root: Path, index_ref: str, *, force: bool = False) -> dict:
+    index_dir, meta, meta_error, resolved_by = _resolve_index_ref(cache_root, index_ref)
+    index_key = index_dir.name
+    if meta:
+        index_key = meta.get("index_key") or index_key
+
+    if (meta is None or meta_error is not None) and not force:
+        raise ValueError(
+            f"Index metadata missing or invalid for {index_ref}. Use --force to remove."
+        )
+
+    running = _daemon_running(cache_root, index_key, meta)
+    if running and not force:
+        raise ValueError(
+            "Index appears to have a running daemon. Stop it first or pass --force."
+        )
+
+    size_bytes = _dir_size_bytes(index_dir)
+    shutil.rmtree(index_dir)
+    _clear_port_file(cache_root, index_key, meta)
+
+    return {
+        "index_id": meta.get("index_id") if meta else None,
+        "index_key": index_key,
+        "index_dir": str(index_dir),
+        "resolved_by": resolved_by,
+        "removed": True,
+        "daemon_running": running,
+        "freed_bytes": size_bytes,
+    }
+
+
+def gc_indexes(
+    cache_root: Path,
+    *,
+    days: int | None = None,
+    max_total_mb: float | None = None,
+    force: bool = False,
+) -> dict:
+    if days is None and max_total_mb is None:
+        raise ValueError("gc requires --days and/or --max-total-mb")
+
+    entries = []
+    for index_dir in _iter_index_dirs(cache_root):
+        meta_path = index_dir / "meta.json"
+        meta, meta_error = _read_meta(meta_path)
+        size_bytes = _dir_size_bytes(index_dir)
+        index_key = meta.get("index_key") if meta else index_dir.name
+        last_used_at = _extract_last_used(meta, meta_path, index_dir)
+        last_used_dt = _parse_iso(last_used_at)
+        entry = {
+            "index_dir": index_dir,
+            "index_id": meta.get("index_id") if meta else None,
+            "index_key": index_key,
+            "meta": meta,
+            "meta_error": meta_error,
+            "size_bytes": size_bytes,
+            "last_used_at": last_used_at,
+            "last_used_dt": last_used_dt,
+            "daemon_running": _daemon_running(cache_root, index_key, meta),
+        }
+        entries.append(entry)
+
+    to_remove: dict[str, dict] = {}
+    skipped: list[dict] = []
+    now = datetime.now(timezone.utc)
+
+    def mark_skip(entry: dict, reason: str) -> None:
+        skipped.append(
+            {
+                "index_id": entry.get("index_id"),
+                "index_key": entry.get("index_key"),
+                "index_dir": str(entry.get("index_dir")),
+                "reason": reason,
+            }
+        )
+
+    def can_remove(entry: dict) -> bool:
+        if entry.get("daemon_running") and not force:
+            mark_skip(entry, "daemon running")
+            return False
+        if entry.get("meta_error") and not force:
+            mark_skip(entry, entry.get("meta_error") or "invalid meta")
+            return False
+        return True
+
+    if days is not None:
+        cutoff = now - timedelta(days=days)
+        for entry in entries:
+            last_used = entry.get("last_used_dt")
+            if last_used is None or last_used >= cutoff:
+                continue
+            if not can_remove(entry):
+                continue
+            to_remove[str(entry["index_dir"])] = {"entry": entry, "reason": "age"}
+
+    if max_total_mb is not None:
+        max_bytes = int(max_total_mb * 1024 * 1024)
+        remaining = [
+            entry
+            for entry in entries
+            if str(entry["index_dir"]) not in to_remove
+        ]
+        total_bytes = sum(entry.get("size_bytes", 0) for entry in remaining)
+        if total_bytes > max_bytes:
+            remaining_sorted = sorted(
+                remaining,
+                key=lambda e: (
+                    e.get("last_used_dt") is None,
+                    e.get("last_used_dt") or datetime.min.replace(tzinfo=timezone.utc),
+                ),
+            )
+            for entry in remaining_sorted:
+                if total_bytes <= max_bytes:
+                    break
+                if not can_remove(entry):
+                    continue
+                to_remove[str(entry["index_dir"])] = {
+                    "entry": entry,
+                    "reason": "size",
+                }
+                total_bytes -= entry.get("size_bytes", 0)
+
+    removed: list[dict] = []
+    freed_bytes = 0
+    for item in to_remove.values():
+        entry = item["entry"]
+        index_dir = entry["index_dir"]
+        size_bytes = entry.get("size_bytes", 0)
+        try:
+            shutil.rmtree(index_dir)
+            _clear_port_file(cache_root, entry.get("index_key"), entry.get("meta"))
+            freed_bytes += size_bytes
+            removed.append(
+                {
+                    "index_id": entry.get("index_id"),
+                    "index_key": entry.get("index_key"),
+                    "index_dir": str(index_dir),
+                    "reason": item["reason"],
+                    "freed_bytes": size_bytes,
+                }
+            )
+        except OSError as exc:
+            mark_skip(entry, f"failed to remove: {exc}")
+
+    remaining_entries = [
+        entry
+        for entry in entries
+        if str(entry["index_dir"]) not in to_remove
+    ]
+    remaining_bytes = sum(entry.get("size_bytes", 0) for entry in remaining_entries)
+
+    return {
+        "cache_root": str(cache_root),
+        "criteria": {
+            "days": days,
+            "max_total_mb": max_total_mb,
+            "force": force,
+        },
+        "removed": removed,
+        "skipped": skipped,
+        "total_freed_bytes": freed_bytes,
+        "remaining_bytes": remaining_bytes,
+    }

--- a/tldr/patch.py
+++ b/tldr/patch.py
@@ -20,7 +20,6 @@ Usage:
 
 from __future__ import annotations
 
-import ast
 import hashlib
 from dataclasses import dataclass
 from pathlib import Path

--- a/tldr/salsa.py
+++ b/tldr/salsa.py
@@ -35,13 +35,11 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Generic,
     List,
     Optional,
     Set,
     Tuple,
     TypeVar,
-    Union,
 )
 
 # Type variables for generic query handling

--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -19,7 +19,7 @@ import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Tuple, Dict, Any
+from typing import List, Optional, Dict, Any
 
 logger = logging.getLogger("tldr.semantic")
 
@@ -185,7 +185,7 @@ def _confirm_download(model_key: str) -> bool:
 
     print(f"\n⚠️  Semantic search requires embedding model: {hf_name}", file=sys.stderr)
     print(f"   Download size: {size}", file=sys.stderr)
-    print(f"   (Set TLDR_AUTO_DOWNLOAD=1 to skip this prompt)\n", file=sys.stderr)
+    print("   (Set TLDR_AUTO_DOWNLOAD=1 to skip this prompt)\n", file=sys.stderr)
 
     try:
         response = input("Continue with download? [Y/n] ").strip().lower()
@@ -251,7 +251,7 @@ def get_model(model_name: Optional[str] = None, device: Optional[str] = None):
     if not _model_exists_locally(hf_name):
         model_key = model_name if model_name in SUPPORTED_MODELS else None
         if model_key and not _confirm_download(model_key):
-            raise ValueError(f"Model download declined. Use --model to choose a smaller model.")
+            raise ValueError("Model download declined. Use --model to choose a smaller model.")
 
     logger.info("Loading model %s on device: %s", hf_name, device)
     from sentence_transformers import SentenceTransformer
@@ -362,7 +362,7 @@ def extract_units_from_project(
     Returns:
         List of EmbeddingUnit objects with enriched metadata.
     """
-    from tldr.api import get_code_structure, build_project_call_graph, get_imports
+    from tldr.api import get_code_structure, build_project_call_graph
     from tldr.tldrignore import IgnoreSpec
 
     project = Path(project_path).resolve()
@@ -1197,8 +1197,6 @@ def build_semantic_index(
     if not units:
         return 0
 
-    import numpy as np
-
     BATCH_SIZE = 64
     num_units = len(units)
     texts = [build_embedding_text(unit) for unit in units]
@@ -1303,8 +1301,6 @@ def semantic_search(
     Returns:
         List of result dictionaries with name, file, line, score, etc.
     """
-    import numpy as np
-
     # Handle empty query
     if not query or not query.strip():
         return []

--- a/tldr/stats.py
+++ b/tldr/stats.py
@@ -283,14 +283,18 @@ class HookStatsStore:
     Location: {project}/.tldr/stats/hook_activity.jsonl
     """
 
-    def __init__(self, project_path: Path | str):
+    def __init__(self, project_path: Path | str, *, stats_dir: Path | str | None = None):
         """Initialize hook stats store for a project.
 
         Args:
             project_path: Root path of the project
+            stats_dir: Optional override for stats directory (index mode)
         """
         self.project = Path(project_path)
-        self.stats_dir = self.project / ".tldr" / "stats"
+        if stats_dir is None:
+            self.stats_dir = self.project / ".tldr" / "stats"
+        else:
+            self.stats_dir = Path(stats_dir)
         self.path = self.stats_dir / "hook_activity.jsonl"
 
     def load(self) -> dict[str, HookStats]:

--- a/uv.lock
+++ b/uv.lock
@@ -893,7 +893,7 @@ wheels = [
 
 [[package]]
 name = "llm-tldr"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added index management commands: list, info, remove, and garbage collection.
  * Introduced isolated dependency indexing with separate cache layouts.
  * Added device selection (CPU/CUDA/MPS) for semantic embeddings.
  * New agent skills for repository indexing and dependency analysis.

* **Documentation**
  * Added benchmarking guide with performance metrics and test scenarios.
  * Added agent skills documentation for code indexing workflows.
  * Added implementation specifications for index isolation.

* **Tests**
  * Expanded test coverage for index management and isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements isolated index support, enabling TLDR to analyze dependencies in-place while storing all caches under a designated repository root. This addresses the core problem where LLMs struggle with dependency documentation by allowing direct indexing of installed packages without copying them or polluting dependency directories with TLDR artifacts.

## Key Changes

- **New Index Abstraction**: Introduced `IndexConfig`, `IndexPaths`, and `IndexContext` dataclasses in `tldr/indexing/index.py` to manage per-dependency isolated state under `cache_root/.tldr/indexes/{index_key}/`
- **CLI Flag Support**: Added `--cache-root`, `--scan-root`, and `--index` flags to all subcommands via argparse parent parser pattern, enabling flexible root specification
- **Daemon Identity Isolation**: Created `tldr/daemon/identity.py` to key daemon socket/pid/lock/port files by `(cache_root, index_key)` hash, allowing multiple daemons per repository
- **Semantic Index Isolation**: Updated `tldr/semantic.py` to support index-scoped FAISS caches with model validation, device selection (CPU default on macOS for stability), and proper ignore spec threading
- **Ignore Configuration**: Enhanced `IgnoreSpec` class to support custom ignore file paths and gitignore roots, enabling index-scoped ignore rules that don't rely on dependency directory structure
- **Workspace Config Rebasing**: Implemented pattern rebasing in `tldr/cross_file_calls.py` so `.claude/workspace.json` patterns work correctly when `scan_root` is a subdirectory of `cache_root`
- **Index Management**: Added `tldr index list/info/rm/gc` commands with daemon-running safety checks and port file cleanup
- **No Writes to Scan Root**: Enforced strict isolation - when `scan_root != cache_root`, TLDR creates no `.tldr*` artifacts under `scan_root`

## Test Coverage

Comprehensive test suite added covering:
- Index path collision avoidance (`test_index_paths.py`)
- Semantic index isolation (`test_semantic_index_isolated.py`)
- Daemon identity isolation (`test_daemon_identity.py`, `test_daemon_index_mode.py`)
- No writes outside cache root (`test_no_writes_outside_cache_root.py`)
- Workspace config rebasing (`test_workspace_config_rebase.py`)
- Index management operations (`test_index_management.py`)
- CLI flag parsing (`test_cli_parsing_index_flags.py`)
- Ignore scoping (`test_ignore_index_scoped.py`)

## Architecture

The implementation follows a clean separation between legacy mode (existing behavior, unchanged) and index mode (new isolated behavior). Index mode activates when `--cache-root` is specified. All persisted state (call graphs, semantic FAISS indexes, metadata) is namespaced under `cache_root/.tldr/indexes/{index_key}/` where `index_key` is a hash-based filesystem-safe identifier.

## Skills & Documentation

New skills enable LLM-driven dependency indexing:
- `llm-tldr-dep-indexer`: Resolves Node.js and Python dependency paths/versions and indexes them
- `llm-tldr-usage`: Updated with index mode usage examples

Extensive documentation in `specs/001-feat-isolated-index.md` and `implementations/001-feat-isolated-index.md` covers requirements, phasing, gotchas, and implementation details.

<h3>Confidence Score: 4/5</h3>

- This PR is well-architected with comprehensive test coverage and documentation, though the large surface area warrants thorough integration testing in production-like scenarios
- Score reflects excellent engineering practices (clean abstractions, thorough tests, detailed docs) but acknowledges complexity risks: 50 files changed with deep threading through daemon/semantic/CLI layers. The isolation guarantees are critical and well-tested, but real-world edge cases (Windows paths, concurrent access, model mismatches) need validation
- Pay close attention to `tldr/daemon/core.py` and `tldr/daemon/startup.py` for Windows daemon spawn behavior and port collision handling. Verify `tldr/semantic.py` model validation prevents dimension mismatches in production

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tldr/indexing/index.py | New module implements core index abstraction with IndexConfig, IndexPaths, IndexContext dataclasses and meta.json handling. Clean design with proper path normalization and validation. |
| tldr/indexing/management.py | Implements index management commands (list/info/rm/gc) with daemon-running safety checks and proper error handling. Port file cleanup included. |
| tldr/daemon/identity.py | New module handles daemon identity resolution for both legacy and index modes. Properly keys socket/pid/lock/port files by (cache_root, index_key) hash. |
| tldr/semantic.py | Updated to support index-scoped semantic caches with model validation, device selection (CPU default on macOS), and proper ignore spec threading. Includes workspace config rebasing. |
| tldr/cli.py | Major refactor adds index parent parser with --scan-root, --cache-root, --index flags. All subcommands now accept index flags via parent parser pattern. Index management subcommands added. |
| tldr/tldrignore.py | Enhanced IgnoreSpec class now supports custom ignore_file and gitignore_root paths. Added resolve_git_root() helper. Properly handles index-scoped ignore configuration. |
| tldr/cross_file_calls.py | Updated to accept ignore_spec and workspace_root parameters. Implements workspace config pattern rebasing for subdirectory scans. Always prunes .tldr/ to prevent self-indexing. |
| tldr/daemon/core.py | Refactored to use IndexConfig and daemon identity helpers. Reads config from cache_root in index mode. Background reindex propagates index flags properly. |
| tldr/daemon/startup.py | Updated daemon startup to use identity module and accept index flags. Windows spawn propagates index configuration. Port collision mitigation via persisted port file. |
| tests/test_no_writes_outside_cache_root.py | Critical test verifies warm command doesn't create .tldr* under scan_root when scan_root != cache_root. Validates core isolation requirement. |
| tests/test_index_management.py | Tests index CLI commands (list/info/rm/gc), daemon-running guards, and GC age-based removal logic. Good coverage of management operations. |
| tests/test_semantic_index_isolated.py | Tests semantic index isolation - verifies two indexes under one cache_root don't collide and produce different search results. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant IndexContext
    participant IndexPaths
    participant Daemon
    participant SemanticIndex
    participant CallGraph
    
    Note over User,CallGraph: Index Mode Initialization
    User->>CLI: tldr warm --cache-root=repo --scan-root=node_modules/pkg --index=node:pkg@1.0
    CLI->>IndexContext: get_index_context(scan_root, cache_root, index_id)
    IndexContext->>IndexPaths: from_config(IndexConfig)
    IndexPaths-->>IndexContext: paths (cache_root/.tldr/indexes/{index_key}/)
    IndexContext->>IndexPaths: ensure_index(allow_create=true)
    IndexPaths->>IndexPaths: load or create meta.json with scan_root binding
    IndexPaths-->>CLI: IndexContext with paths + config
    
    Note over CLI,CallGraph: Building Call Graph (Isolated)
    CLI->>CallGraph: build_project_call_graph(scan_root, ignore_spec)
    CallGraph->>CallGraph: scan_project(scan_root, ignore_spec)
    CallGraph->>IndexPaths: write to cache_root/.tldr/indexes/{index_key}/cache/call_graph.json
    CallGraph-->>CLI: call graph saved (no writes to scan_root)
    
    Note over User,Daemon: Daemon with Index Identity
    User->>CLI: tldr daemon start --cache-root=repo --index=node:pkg@1.0
    CLI->>Daemon: resolve_daemon_identity(cache_root, index_key)
    Daemon->>Daemon: hash(cache_root + index_key) -> identity
    Daemon->>Daemon: create socket at /tmp/tldr-{hash}.sock
    Daemon->>IndexPaths: load config from cache_root/.tldr/config.json
    Daemon-->>CLI: daemon started with isolated identity
    
    Note over User,SemanticIndex: Semantic Index (Isolated)
    User->>CLI: tldr semantic index --cache-root=repo --scan-root=node_modules/pkg --index=node:pkg@1.0
    CLI->>SemanticIndex: build_semantic_index(scan_root, index_paths, index_config)
    SemanticIndex->>SemanticIndex: extract_units_from_project(scan_root, ignore_spec, workspace_root)
    SemanticIndex->>SemanticIndex: compute embeddings with model
    SemanticIndex->>IndexPaths: write FAISS to cache_root/.tldr/indexes/{index_key}/cache/semantic/
    SemanticIndex->>IndexPaths: update meta.json with semantic.model + dim
    SemanticIndex-->>CLI: indexed N units (no writes to scan_root)
    
    Note over User,Daemon: Query via Daemon
    User->>Daemon: semantic search "query" (via socket)
    Daemon->>IndexPaths: load FAISS from cache_root/.tldr/indexes/{index_key}/cache/semantic/
    Daemon->>Daemon: validate model matches meta.json
    Daemon-->>User: search results from correct index
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->