### PR TITLE
respect .tldrignore in get_code_structure() when ignore_spec is None

### DIFF
--- a/tests/test_ignore_patterns.py
+++ b/tests/test_ignore_patterns.py
@@ -1,0 +1,317 @@
+"""Tests for .tldrignore pattern handling in API functions.
+
+This test suite verifies that get_code_structure() and analyze_dead_code()
+properly respect .tldrignore patterns by default, fixing the bug where
+node_modules and other ignored directories were included in results.
+
+Related PR: https://github.com/parcadei/llm-tldr/pull/50
+"""
+
+from pathlib import Path
+
+
+class TestGetCodeStructureIgnorePatterns:
+    """Test that get_code_structure() respects .tldrignore by default."""
+
+    def test_respects_tldrignore_by_default(self, tmp_path: Path):
+        """get_code_structure() should auto-create IgnoreSpec when ignore_spec=None.
+
+        This tests the fix for the bug where node_modules was included in results,
+        causing 99.8% false positives in dead code analysis.
+        """
+        from tldr.api import get_code_structure
+
+        # Setup: Create project structure
+        project = tmp_path / "project"
+        project.mkdir()
+
+        # Create .tldrignore
+        (project / ".tldrignore").write_text("node_modules/\n.venv/\n")
+
+        # Create source file
+        src_dir = project / "src"
+        src_dir.mkdir()
+        (src_dir / "main.py").write_text("def hello():\n    pass\n")
+
+        # Create ignored files
+        nm_dir = project / "node_modules" / "package"
+        nm_dir.mkdir(parents=True)
+        (nm_dir / "index.py").write_text("def ignored_func():\n    pass\n")
+
+        venv_dir = project / ".venv" / "lib"
+        venv_dir.mkdir(parents=True)
+        (venv_dir / "lib.py").write_text("def venv_func():\n    pass\n")
+
+        # Action: Call get_code_structure without ignore_spec
+        result = get_code_structure(str(project), language="python", max_results=100)
+
+        # Assert: No ignored files included
+        file_paths = [f["path"] for f in result.get("files", [])]
+        node_modules_files = [p for p in file_paths if "node_modules" in p]
+        venv_files = [p for p in file_paths if ".venv" in p]
+
+        assert len(node_modules_files) == 0, (
+            f"Expected no node_modules files, but found: {node_modules_files}"
+        )
+        assert len(venv_files) == 0, (
+            f"Expected no .venv files, but found: {venv_files}"
+        )
+        assert len(file_paths) == 1, f"Expected 1 file, found {len(file_paths)}: {file_paths}"
+        assert "src/main.py" in file_paths[0] or "src\\main.py" in file_paths[0], (
+            f"Expected src/main.py, got {file_paths}"
+        )
+
+    def test_explicit_ignore_spec_still_works(self, tmp_path: Path):
+        """Passing explicit ignore_spec should override auto-creation (backward compat)."""
+        from tldr.api import get_code_structure
+        from tldr.tldrignore import IgnoreSpec
+
+        # Setup: Create project with .tldrignore
+        project = tmp_path / "project"
+        project.mkdir()
+
+        (project / ".tldrignore").write_text("node_modules/\n")
+
+        # Create files
+        (project / "main.py").write_text("def main():\n    pass\n")
+
+        nm_dir = project / "node_modules"
+        nm_dir.mkdir()
+        (nm_dir / "lib.py").write_text("def lib():\n    pass\n")
+
+        # Create custom IgnoreSpec that ignores main.py instead
+        custom_spec = IgnoreSpec(project, use_gitignore=False)
+        # Note: We can't easily modify IgnoreSpec patterns, so we'll test that
+        # passing explicit ignore_spec doesn't auto-create a new one
+
+        # Action: Pass explicit ignore_spec (empty/custom one)
+        result = get_code_structure(
+            str(project),
+            language="python",
+            max_results=100,
+            ignore_spec=custom_spec
+        )
+
+        # Assert: Uses the explicit spec, not auto-created one
+        # This test mainly verifies backward compatibility - explicit ignore_spec is honored
+        file_paths = [f["path"] for f in result.get("files", [])]
+        assert len(file_paths) >= 1, "Should find files when explicit ignore_spec is passed"
+
+    def test_respect_ignore_false_includes_ignored_files(self, tmp_path: Path):
+        """Setting respect_ignore=False should include all files (opt-out)."""
+        from tldr.api import get_code_structure
+
+        # Setup: Create project with .tldrignore
+        project = tmp_path / "project"
+        project.mkdir()
+
+        (project / ".tldrignore").write_text("node_modules/\n")
+
+        # Create files
+        (project / "main.py").write_text("def main():\n    pass\n")
+
+        nm_dir = project / "node_modules"
+        nm_dir.mkdir()
+        (nm_dir / "lib.py").write_text("def lib():\n    pass\n")
+
+        # Action: Call with respect_ignore=False
+        result = get_code_structure(
+            str(project),
+            language="python",
+            max_results=100,
+            respect_ignore=False
+        )
+
+        # Assert: All files included, even node_modules
+        file_paths = [f["path"] for f in result.get("files", [])]
+        node_modules_files = [p for p in file_paths if "node_modules" in p]
+
+        assert len(node_modules_files) > 0, (
+            "Expected node_modules files when respect_ignore=False, but found none"
+        )
+        assert len(file_paths) == 2, (
+            f"Expected 2 files (main.py + node_modules/lib.py), found {len(file_paths)}"
+        )
+
+    def test_respects_gitignore_when_no_tldrignore(self, tmp_path: Path):
+        """Should respect .gitignore patterns when .tldrignore is missing."""
+        from tldr.api import get_code_structure
+
+        # Setup: Create project with only .gitignore (no .tldrignore)
+        project = tmp_path / "project"
+        project.mkdir()
+
+        # Create .gitignore instead of .tldrignore
+        (project / ".gitignore").write_text("__pycache__/\n*.pyc\n")
+
+        # Create files
+        (project / "main.py").write_text("def main():\n    pass\n")
+
+        cache_dir = project / "__pycache__"
+        cache_dir.mkdir()
+        (cache_dir / "main.cpython-39.pyc").write_text("bytecode")
+
+        # Action: Call get_code_structure (should use gitignore)
+        result = get_code_structure(str(project), language="python", max_results=100)
+
+        # Assert: __pycache__ files excluded
+        file_paths = [f["path"] for f in result.get("files", [])]
+        cache_files = [p for p in file_paths if "__pycache__" in p]
+
+        assert len(cache_files) == 0, (
+            f"Expected no __pycache__ files, but found: {cache_files}"
+        )
+        assert len(file_paths) == 1, f"Expected 1 file, found {len(file_paths)}"
+
+
+class TestAnalyzeDeadCodeIgnorePatterns:
+    """Test that analyze_dead_code() respects .tldrignore."""
+
+    def test_dead_code_excludes_ignored_directories(self, tmp_path: Path):
+        """analyze_dead_code() should not report functions from ignored directories.
+
+        This is the primary bug fix - dead code analysis was reporting 99.8%
+        false positives from node_modules.
+        """
+        from tldr.api import get_code_structure
+
+        # Setup: Create project with node_modules
+        project = tmp_path / "project"
+        project.mkdir()
+
+        (project / ".tldrignore").write_text("node_modules/\n")
+
+        # Create main source file
+        (project / "main.py").write_text("""
+def main():
+    used_function()
+
+def used_function():
+    pass
+
+def unused_function():
+    pass
+""")
+
+        # Create node_modules with "dead" code
+        nm_dir = project / "node_modules" / "package"
+        nm_dir.mkdir(parents=True)
+        (nm_dir / "index.py").write_text("""
+def node_modules_func():
+    pass
+
+def another_nm_func():
+    pass
+""")
+
+        # Action: Get code structure (which is what analyze_dead_code uses internally)
+        result = get_code_structure(str(project), language="python", max_results=100)
+
+        # Assert: No functions from node_modules in structure
+        files = result.get("files", [])
+        node_modules_files = [
+            f for f in files
+            if "node_modules" in f.get("path", "")
+        ]
+
+        assert len(node_modules_files) == 0, (
+            f"Expected no node_modules files in structure, but found: {node_modules_files}"
+        )
+
+        # Should find main.py
+        file_paths = [f.get("path") for f in files]
+        main_files = [p for p in file_paths if "main.py" in p]
+        assert len(main_files) == 1, (
+            f"Expected to find main.py, but found: {file_paths}"
+        )
+
+
+class TestSemanticExtractRespectIgnore:
+    """Test semantic.py extract_units_from_project() respects respect_ignore flag."""
+
+    def test_extract_units_propagates_respect_ignore_false(self, tmp_path: Path):
+        """Verify extract_units_from_project propagates respect_ignore=False correctly.
+
+        This tests the fix for the Sentry-reported bug where semantic.py wasn't
+        passing the respect_ignore flag to get_code_structure.
+        """
+        from tldr.semantic import extract_units_from_project
+
+        # Setup: Create project with .tldrignore
+        project = tmp_path / "project"
+        project.mkdir()
+
+        (project / ".tldrignore").write_text("vendor/\n")
+
+        # Create main file
+        (project / "main.py").write_text("""
+def main():
+    '''Main function'''
+    pass
+""")
+
+        # Create ignored vendor file
+        vendor_dir = project / "vendor"
+        vendor_dir.mkdir()
+        (vendor_dir / "lib.py").write_text("""
+def vendor_lib():
+    '''Vendor library function'''
+    pass
+""")
+
+        # Action: Call with respect_ignore=False
+        units = extract_units_from_project(
+            str(project),
+            lang="python",
+            respect_ignore=False
+        )
+
+        # Assert: Should include vendor files
+        # Note: EmbeddingUnit has 'file' attribute, not 'file_path'
+        unit_paths = [u.file for u in units]
+        vendor_units = [p for p in unit_paths if "vendor" in p]
+
+        assert len(vendor_units) > 0, (
+            "Expected vendor/ files when respect_ignore=False, but found none. "
+            "This indicates the flag wasn't propagated to get_code_structure."
+        )
+
+
+class TestIgnorePatternEdgeCases:
+    """Edge cases for ignore pattern handling."""
+
+    def test_works_without_ignore_files(self, tmp_path: Path):
+        """Should work gracefully when neither .tldrignore nor .gitignore exist."""
+        from tldr.api import get_code_structure
+
+        # Setup: Create project without any ignore files
+        project = tmp_path / "project"
+        project.mkdir()
+
+        (project / "main.py").write_text("def main():\n    pass\n")
+
+        # Action: Call get_code_structure
+        result = get_code_structure(str(project), language="python", max_results=100)
+
+        # Assert: Should work without errors
+        file_paths = [f["path"] for f in result.get("files", [])]
+        assert len(file_paths) == 1, "Should find the main.py file"
+
+    def test_empty_tldrignore(self, tmp_path: Path):
+        """Should handle empty .tldrignore file gracefully."""
+        from tldr.api import get_code_structure
+
+        # Setup: Create project with empty .tldrignore
+        project = tmp_path / "project"
+        project.mkdir()
+
+        (project / ".tldrignore").write_text("")  # Empty file
+
+        (project / "main.py").write_text("def main():\n    pass\n")
+
+        # Action: Call get_code_structure
+        result = get_code_structure(str(project), language="python", max_results=100)
+
+        # Assert: Should work without errors
+        file_paths = [f["path"] for f in result.get("files", [])]
+        assert len(file_paths) == 1, "Should find the main.py file with empty .tldrignore"

--- a/tests/test_ignore_patterns.py
+++ b/tests/test_ignore_patterns.py
@@ -137,8 +137,16 @@ class TestGetCodeStructureIgnorePatterns:
 
     def test_respects_gitignore_when_no_tldrignore(self, tmp_path: Path):
         """Should respect .gitignore patterns when .tldrignore is missing."""
+        import shutil
         import subprocess
+
+        import pytest
+
         from tldr.api import get_code_structure
+
+        # Skip test if git is not installed
+        if not shutil.which("git"):
+            pytest.skip("git not installed")
 
         # Setup: Create project with only .gitignore (no .tldrignore)
         project = tmp_path / "project"

--- a/tests/test_ignore_patterns.py
+++ b/tests/test_ignore_patterns.py
@@ -135,33 +135,41 @@ class TestGetCodeStructureIgnorePatterns:
 
     def test_respects_gitignore_when_no_tldrignore(self, tmp_path: Path):
         """Should respect .gitignore patterns when .tldrignore is missing."""
+        import subprocess
         from tldr.api import get_code_structure
 
         # Setup: Create project with only .gitignore (no .tldrignore)
         project = tmp_path / "project"
         project.mkdir()
 
-        # Create .gitignore instead of .tldrignore
-        (project / ".gitignore").write_text("__pycache__/\n*.pyc\n")
+        # Initialize as git repo (required for gitignore checking)
+        subprocess.run(["git", "init"], cwd=project, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=project, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=project, capture_output=True, check=True)
+
+        # Create .gitignore with a directory pattern
+        (project / ".gitignore").write_text("build_output/\n")
 
         # Create files
         (project / "main.py").write_text("def main():\n    pass\n")
 
-        cache_dir = project / "__pycache__"
-        cache_dir.mkdir()
-        (cache_dir / "main.cpython-39.pyc").write_text("bytecode")
+        # Create a .py file in an ignored directory
+        # This tests that .gitignore actually filters, not just extension filtering
+        build_dir = project / "build_output"
+        build_dir.mkdir()
+        (build_dir / "generated.py").write_text("def generated():\n    pass\n")
 
         # Action: Call get_code_structure (should use gitignore)
         result = get_code_structure(str(project), language="python", max_results=100)
 
-        # Assert: __pycache__ files excluded
+        # Assert: build_output files excluded
         file_paths = [f["path"] for f in result.get("files", [])]
-        cache_files = [p for p in file_paths if "__pycache__" in p]
+        ignored_files = [p for p in file_paths if "build_output" in p]
 
-        assert len(cache_files) == 0, (
-            f"Expected no __pycache__ files, but found: {cache_files}"
+        assert len(ignored_files) == 0, (
+            f"Expected no build_output files, but found: {ignored_files}"
         )
-        assert len(file_paths) == 1, f"Expected 1 file, found {len(file_paths)}"
+        assert len(file_paths) == 1, f"Expected 1 file (main.py), found {len(file_paths)}"
 
 
 class TestAnalyzeDeadCodeIgnorePatterns:

--- a/tests/test_ignore_patterns.py
+++ b/tests/test_ignore_patterns.py
@@ -26,7 +26,7 @@ class TestGetCodeStructureIgnorePatterns:
         project.mkdir()
 
         # Create .tldrignore
-        (project / ".tldrignore").write_text("node_modules/\n.venv/\n")
+        (project / ".tldrignore").write_text("node_modules/\nvendor/\n")
 
         # Create source file
         src_dir = project / "src"
@@ -38,9 +38,11 @@ class TestGetCodeStructureIgnorePatterns:
         nm_dir.mkdir(parents=True)
         (nm_dir / "index.py").write_text("def ignored_func():\n    pass\n")
 
-        venv_dir = project / ".venv" / "lib"
-        venv_dir.mkdir(parents=True)
-        (venv_dir / "lib.py").write_text("def venv_func():\n    pass\n")
+        # Use vendor/ instead of .venv/ because get_code_structure filters hidden files
+        # This ensures we're actually testing .tldrignore, not just hidden-file filtering
+        vendor_dir = project / "vendor" / "lib"
+        vendor_dir.mkdir(parents=True)
+        (vendor_dir / "lib.py").write_text("def vendor_func():\n    pass\n")
 
         # Action: Call get_code_structure without ignore_spec
         result = get_code_structure(str(project), language="python", max_results=100)
@@ -48,13 +50,13 @@ class TestGetCodeStructureIgnorePatterns:
         # Assert: No ignored files included
         file_paths = [f["path"] for f in result.get("files", [])]
         node_modules_files = [p for p in file_paths if "node_modules" in p]
-        venv_files = [p for p in file_paths if ".venv" in p]
+        vendor_files = [p for p in file_paths if "vendor" in p]
 
         assert len(node_modules_files) == 0, (
             f"Expected no node_modules files, but found: {node_modules_files}"
         )
-        assert len(venv_files) == 0, (
-            f"Expected no .venv files, but found: {venv_files}"
+        assert len(vendor_files) == 0, (
+            f"Expected no vendor files, but found: {vendor_files}"
         )
         assert len(file_paths) == 1, f"Expected 1 file, found {len(file_paths)}: {file_paths}"
         assert "src/main.py" in file_paths[0] or "src\\main.py" in file_paths[0], (

--- a/tldr/api.py
+++ b/tldr/api.py
@@ -1516,6 +1516,7 @@ def get_code_structure(
     language: str = "python",
     max_results: int = 100,
     ignore_spec=None,
+    respect_ignore: bool = True,
 ) -> dict:
     """
     Get code structure (codemaps) for all files in a project.
@@ -1525,6 +1526,8 @@ def get_code_structure(
         language: Language to analyze ("python", "typescript", "go", "rust")
         max_results: Maximum number of files to analyze (default 100)
         ignore_spec: Optional pathspec.PathSpec for gitignore-style patterns
+        respect_ignore: If True and ignore_spec is None, auto-create IgnoreSpec
+                       from .tldrignore and .gitignore (default True)
 
     Returns:
         Dict with codemap structure:
@@ -1542,6 +1545,11 @@ def get_code_structure(
         }
     """
     root = Path(root)
+    
+    # Auto-create IgnoreSpec if not provided and respect_ignore is True
+    if respect_ignore and ignore_spec is None:
+        from .tldrignore import IgnoreSpec
+        ignore_spec = IgnoreSpec(root, use_gitignore=True)
 
     # Get extension map for language
     ext_map = {

--- a/tldr/api.py
+++ b/tldr/api.py
@@ -1516,6 +1516,7 @@ def get_code_structure(
     language: str = "python",
     max_results: int = 100,
     ignore_spec=None,
+    *,
     respect_ignore: bool = True,
 ) -> dict:
     """

--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -310,7 +310,7 @@ def extract_units_from_project(project_path: str, lang: str = "python", respect_
     ignore_spec = load_ignore_patterns(project) if respect_ignore else None
 
     # Get code structure (L1) - use high limit for semantic index
-    structure = get_code_structure(str(project), language=lang, max_results=100000, ignore_spec=ignore_spec)
+    structure = get_code_structure(str(project), language=lang, max_results=100000, ignore_spec=ignore_spec, respect_ignore=respect_ignore)
 
     # Filter ignored files
     if respect_ignore:

--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -306,19 +306,9 @@ def extract_units_from_project(project_path: str, lang: str = "python", respect_
     project = Path(project_path).resolve()
     units = []
 
-    # Load ignore spec before getting structure
-    ignore_spec = load_ignore_patterns(project) if respect_ignore else None
-
     # Get code structure (L1) - use high limit for semantic index
-    structure = get_code_structure(str(project), language=lang, max_results=100000, ignore_spec=ignore_spec, respect_ignore=respect_ignore)
-
-    # Filter ignored files
-    if respect_ignore:
-        spec = load_ignore_patterns(project)
-        structure["files"] = [
-            f for f in structure.get("files", [])
-            if not should_ignore(project / f.get("path", ""), project, spec)
-        ]
+    # Let get_code_structure auto-create IgnoreSpec with both .tldrignore and .gitignore
+    structure = get_code_structure(str(project), language=lang, max_results=100000, respect_ignore=respect_ignore)
 
     # Build call graph (L2)
     try:


### PR DESCRIPTION
Found this bug due to tldr indexing all of my node_modules. This fix was suggested by Claude, but I have verified it works locally. Specifically, I tested `tldr dead` and `tldr structure`. 76% reduction in false positives for dead and 100% reduction for tldr structure (no node_modules at all). The remaining 24% for dead are not node_modules but just that I'm doing serverless/react stuff which doesn't have the same entry points as Python. Addressing that would introduce more significant changes which may be unwelcome. 

Details:

Previously, get_code_structure() only filtered files when an explicit ignore_spec was passed. Functions like analyze_dead_code() call it without ignore_spec, causing .tldrignore patterns to be ignored.

This resulted in thousands of false positives from node_modules and other ignored directories when running 'tldr dead', 'tldr structure', etc.

Changes:
- Add respect_ignore parameter (default True) to get_code_structure()
- Auto-create IgnoreSpec from .tldrignore/.gitignore when ignore_spec is None and respect_ignore is True
- Backward compatible: explicit ignore_spec still works as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analysis now honors .tldrignore and .gitignore patterns by default.
  * Option added to opt out of honoring ignore files during analysis.

* **Behavior**
  * Ignore-setting is propagated so included/excluded files reflect the chosen option.
  * Falls back to .gitignore when no .tldrignore exists and handles empty/missing ignore files gracefully.
  * Backward compatibility preserved when an explicit ignore specification is provided.

* **Tests**
  * Comprehensive tests added for ignore-file handling, propagation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed bug where `get_code_structure()` ignored `.tldrignore` patterns when called without an explicit `ignore_spec`, causing `tldr dead` and `tldr structure` to index thousands of files from `node_modules` and other ignored directories.

## Changes
- Added `respect_ignore` parameter (default `True`) to `get_code_structure()` at line 1519
- Auto-creates `IgnoreSpec` from `.tldrignore` and `.gitignore` when `ignore_spec=None` and `respect_ignore=True`
- Maintains backward compatibility with explicit `ignore_spec` parameter
- Follows existing pattern from `scan_project_files()` at line 1085

## Impact
- 76% reduction in false positives for `tldr dead` command
- 100% reduction in false positives for `tldr structure` (no `node_modules`)
- Consistent behavior across all TLDR commands

## Issues
- **Missing tests**: Repository guidelines require "all PRs have tests to prove fixes" but no tests were added for this bug fix

<h3>Confidence Score: 3/5</h3>

- Safe to merge with medium confidence pending test coverage
- Code change is minimal (8 lines), follows existing patterns from `scan_project_files()`, and is backward compatible. Logic is sound and solves a real bug. However, score is reduced from 4 to 3 because repository guidelines explicitly require tests for all PRs, and none were provided despite this being a bug fix that warrants verification.
- No files require special attention from a code quality perspective. The implementation is clean and follows existing patterns. However, tests should be added to `tests/` directory before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tldr/api.py | Added `respect_ignore` parameter to `get_code_structure()` to auto-create IgnoreSpec when None, fixing node_modules indexing bug. Logic is sound and backward compatible, but missing required tests. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as tldr CLI (dead/structure)
    participant Analysis as analyze_dead_code()
    participant API as get_code_structure()
    participant Ignore as IgnoreSpec
    participant FS as File System

    User->>CLI: tldr dead / tldr structure
    CLI->>Analysis: analyze_dead_code(path)
    Analysis->>API: get_code_structure(path, ignore_spec=None)
    
    alt respect_ignore=True (NEW)
        API->>Ignore: IgnoreSpec(root, use_gitignore=True)
        Ignore->>FS: Read .tldrignore
        Ignore->>FS: Read .gitignore
        Ignore-->>API: ignore_spec created
    end
    
    API->>FS: Scan files with ignore_spec
    FS-->>API: Filtered file list (no node_modules)
    API-->>Analysis: Structure without ignored files
    Analysis-->>CLI: Dead code report
    CLI-->>User: Results (76% fewer false positives)
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->