### PR TITLE
fix: support .tsx and .jsx in _get_module_exports() module resolution

### DIFF
--- a/tldr/api.py
+++ b/tldr/api.py
@@ -451,24 +451,31 @@ def _get_module_exports(
         RelevantContext with all functions/classes from the module
     """
     ext_map = {
-        "python": ".py",
-        "typescript": ".ts",
-        "go": ".go",
-        "rust": ".rs"
+        "python": [".py"],
+        "typescript": [".ts", ".tsx"],
+        "javascript": [".js", ".jsx"],
+        "go": [".go"],
+        "rust": [".rs"],
     }
-    ext = ext_map.get(language, ".py")
+    extensions = ext_map.get(language, [".py"])
 
     # Try to find the module file
     # module_path "providers/anthropic" -> providers/anthropic.py
-    module_file = project / f"{module_path}{ext}"
+    module_file = None
+    for ext in extensions:
+        candidate = project / f"{module_path}{ext}"
+        if candidate.exists():
+            module_file = candidate
+            break
 
-    if not module_file.exists():
+    if module_file is None:
         # Try as directory with __init__.py (Python package)
         init_file = project / module_path / "__init__.py"
         if init_file.exists():
             module_file = init_file
         else:
-            raise ValueError(f"Module not found: {module_path} (tried {module_file} and {init_file})")
+            tried = ", ".join(str(project / f"{module_path}{e}") for e in extensions)
+            raise ValueError(f"Module not found: {module_path} (tried {tried} and {init_file})")
 
     # Extract all functions and classes from the module
     extractor = HybridExtractor()


### PR DESCRIPTION
## Summary

Fixes #52 — `tldr context` fails to find `.tsx` and `.jsx` files when using module path syntax.

`_get_module_exports()` mapped TypeScript to only `.ts`, so React component files (`.tsx`) were never resolved. Every other ext_map in the codebase already handles this correctly — this one function was inconsistent.

## Changes

- Changed `ext_map` values from single strings to lists of extensions
- Added `.tsx` for TypeScript and `.jsx` for JavaScript
- Module resolution now iterates over candidate extensions
- Error message lists all tried paths

## Testing

Verified against a TypeScript project with `.tsx` React components:

```
# Before (broken):
$ tldr context src/components/CloisterStatusBar --lang typescript
Error: Module not found: src/components/CloisterStatusBar (tried .ts and __init__.py)

# After (fixed):
$ tldr context src/components/CloisterStatusBar --lang typescript
## Code Context: src/components/CloisterStatusBar (depth=0)
📍 fetchCloisterStatus (CloisterStatusBar.tsx:38)
📍 CloisterStatusBar (CloisterStatusBar.tsx:75)
...
📊 7 functions | ~194 tokens
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple file extensions per language (e.g., .ts, .tsx for TypeScript; .js, .jsx for JavaScript)
  * Added JavaScript language module support

* **Improvements**
  * Enhanced error messages to display all attempted file paths when module discovery fails
  * Improved module discovery and fallback handling for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->