### PR TITLE
fix: restore javascript callgraph and context parity

### DIFF
--- a/tests/test_javascript_features.py
+++ b/tests/test_javascript_features.py
@@ -142,6 +142,36 @@ function run() {
     assert ("main.js", "run", "main.js", "work") not in graph.edges
 
 
+@pytest.mark.parametrize("module_ext", [".js", ".cjs"])
+def test_calls_commonjs_default_export_does_not_resolve_to_local_symbol(tmp_path: Path, module_ext: str) -> None:
+    _write(
+        tmp_path / f"worker{module_ext}",
+        """
+function internal(input) {
+  return input + "-i";
+}
+
+module.exports = function (input) {
+  return internal(input);
+};
+""".strip(),
+    )
+    _write(
+        tmp_path / "main.js",
+        """
+const work = require("./worker");
+
+function run() {
+  return work("job");
+}
+""".strip(),
+    )
+
+    graph = build_project_call_graph(tmp_path, language="javascript", use_workspace_config=False)
+    assert ("main.js", "run", f"worker{module_ext}", "default") in graph.edges
+    assert ("main.js", "run", f"worker{module_ext}", "internal") not in graph.edges
+
+
 def test_context_includes_javascript_callee_and_cfg_metrics(tmp_path: Path) -> None:
     _write(
         tmp_path / "helper.js",

--- a/tests/test_javascript_features.py
+++ b/tests/test_javascript_features.py
@@ -1,0 +1,163 @@
+"""Regression tests for JavaScript call-graph and context support."""
+
+from pathlib import Path
+
+import pytest
+
+from tldr.api import get_relevant_context
+from tldr.cross_file_calls import TREE_SITTER_AVAILABLE, build_function_index, build_project_call_graph
+
+
+pytestmark = pytest.mark.skipif(not TREE_SITTER_AVAILABLE, reason="tree-sitter-typescript not available")
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def test_call_graph_dispatch_indexes_javascript_symbols(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "esm.js",
+        """
+export function esHelper(value) {
+  return value.toUpperCase();
+}
+""".strip(),
+    )
+    _write(
+        tmp_path / "cjs.js",
+        """
+exports.helper = function (value) {
+  return value.toLowerCase();
+};
+""".strip(),
+    )
+
+    index = build_function_index(tmp_path, language="javascript")
+
+    assert ("esm", "esHelper") in index
+    assert ("cjs", "helper") in index
+    assert "esm/esHelper" in index
+    assert "cjs/helper" in index
+
+
+def test_calls_builds_edges_for_javascript_esm(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "helper.js",
+        """
+export function helper(input) {
+  return input + "!";
+}
+""".strip(),
+    )
+    _write(
+        tmp_path / "main.js",
+        """
+import { helper } from "./helper.js";
+
+export function main() {
+  return helper("ok");
+}
+""".strip(),
+    )
+
+    graph = build_project_call_graph(tmp_path, language="javascript", use_workspace_config=False)
+    assert ("main.js", "main", "helper.js", "helper") in graph.edges
+
+
+def test_calls_builds_edges_for_javascript_commonjs_destructure(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "helper.js",
+        """
+exports.helper = function (input) {
+  return input + "-done";
+};
+""".strip(),
+    )
+    _write(
+        tmp_path / "main.js",
+        """
+const { helper } = require("./helper");
+
+function main() {
+  return helper("work");
+}
+""".strip(),
+    )
+
+    graph = build_project_call_graph(tmp_path, language="javascript", use_workspace_config=False)
+    assert ("main.js", "main", "helper.js", "helper") in graph.edges
+
+
+def test_calls_builds_edges_for_javascript_commonjs_namespace(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "helper.js",
+        """
+module.exports.helper = function (input) {
+  return input + "-done";
+};
+""".strip(),
+    )
+    _write(
+        tmp_path / "main.js",
+        """
+const helper = require("./helper");
+
+function main() {
+  return helper.helper("work");
+}
+""".strip(),
+    )
+
+    graph = build_project_call_graph(tmp_path, language="javascript", use_workspace_config=False)
+    assert ("main.js", "main", "helper.js", "helper") in graph.edges
+
+
+def test_context_includes_javascript_callee_and_cfg_metrics(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "helper.js",
+        """
+export function helper(value) {
+  return value + "!";
+}
+""".strip(),
+    )
+    _write(
+        tmp_path / "main.js",
+        """
+import { helper } from "./helper.js";
+
+export function main(flag) {
+  if (flag) {
+    return helper("yes");
+  }
+  return helper("no");
+}
+""".strip(),
+    )
+
+    context = get_relevant_context(tmp_path, "main", depth=2, language="javascript")
+    names = {func.name for func in context.functions}
+
+    assert any(name == "main" or name.endswith(".main") for name in names)
+    assert any(name == "helper" or name.endswith(".helper") for name in names)
+
+    main_ctx = next(func for func in context.functions if func.name == "main" or func.name.endswith(".main"))
+    assert main_ctx.blocks is not None
+    assert main_ctx.cyclomatic is not None
+
+
+def test_context_module_query_resolves_mjs(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pkg" / "util.mjs",
+        """
+export function helper(value) {
+  return value + 1;
+}
+""".strip(),
+    )
+
+    context = get_relevant_context(tmp_path, "pkg/util", depth=1, language="javascript")
+    names = {func.name for func in context.functions}
+    assert "helper" in names

--- a/tests/test_javascript_features.py
+++ b/tests/test_javascript_features.py
@@ -66,9 +66,10 @@ export function main() {
     assert ("main.js", "main", "helper.js", "helper") in graph.edges
 
 
-def test_calls_builds_edges_for_javascript_commonjs_destructure(tmp_path: Path) -> None:
+@pytest.mark.parametrize("module_ext", [".js", ".cjs"])
+def test_calls_builds_edges_for_javascript_commonjs_destructure(tmp_path: Path, module_ext: str) -> None:
     _write(
-        tmp_path / "helper.js",
+        tmp_path / f"helper{module_ext}",
         """
 exports.helper = function (input) {
   return input + "-done";
@@ -87,12 +88,13 @@ function main() {
     )
 
     graph = build_project_call_graph(tmp_path, language="javascript", use_workspace_config=False)
-    assert ("main.js", "main", "helper.js", "helper") in graph.edges
+    assert ("main.js", "main", f"helper{module_ext}", "helper") in graph.edges
 
 
-def test_calls_builds_edges_for_javascript_commonjs_namespace(tmp_path: Path) -> None:
+@pytest.mark.parametrize("module_ext", [".js", ".cjs"])
+def test_calls_builds_edges_for_javascript_commonjs_namespace(tmp_path: Path, module_ext: str) -> None:
     _write(
-        tmp_path / "helper.js",
+        tmp_path / f"helper{module_ext}",
         """
 module.exports.helper = function (input) {
   return input + "-done";
@@ -111,7 +113,33 @@ function main() {
     )
 
     graph = build_project_call_graph(tmp_path, language="javascript", use_workspace_config=False)
-    assert ("main.js", "main", "helper.js", "helper") in graph.edges
+    assert ("main.js", "main", f"helper{module_ext}", "helper") in graph.edges
+
+
+@pytest.mark.parametrize("module_ext", [".js", ".cjs"])
+def test_calls_builds_edges_for_javascript_commonjs_default_export(tmp_path: Path, module_ext: str) -> None:
+    _write(
+        tmp_path / f"worker{module_ext}",
+        """
+module.exports = function doThing(input) {
+  return input + "-done";
+};
+""".strip(),
+    )
+    _write(
+        tmp_path / "main.js",
+        """
+const work = require("./worker");
+
+function run() {
+  return work("job");
+}
+""".strip(),
+    )
+
+    graph = build_project_call_graph(tmp_path, language="javascript", use_workspace_config=False)
+    assert ("main.js", "run", f"worker{module_ext}", "doThing") in graph.edges
+    assert ("main.js", "run", "main.js", "work") not in graph.edges
 
 
 def test_context_includes_javascript_callee_and_cfg_metrics(tmp_path: Path) -> None:

--- a/tests/test_language_wiring.py
+++ b/tests/test_language_wiring.py
@@ -15,11 +15,10 @@ import pytest
 from pathlib import Path
 
 # All supported languages and their primary extensions
-# Note: Only includes extensions currently in cli.py EXTENSION_TO_LANGUAGE
 SUPPORTED_LANGUAGES = {
     "python": [".py"],
     "typescript": [".ts", ".tsx"],
-    "javascript": [".js", ".jsx"],  # .mjs/.cjs not in cli.py yet
+    "javascript": [".js", ".jsx", ".mjs", ".cjs"],
     "go": [".go"],
     "rust": [".rs"],
     "java": [".java"],

--- a/tldr/api.py
+++ b/tldr/api.py
@@ -451,24 +451,33 @@ def _get_module_exports(
         RelevantContext with all functions/classes from the module
     """
     ext_map = {
-        "python": ".py",
-        "typescript": ".ts",
-        "go": ".go",
-        "rust": ".rs"
+        "python": [".py"],
+        "typescript": [".ts", ".tsx"],
+        "javascript": [".js", ".jsx", ".mjs", ".cjs"],
+        "go": [".go"],
+        "rust": [".rs"],
     }
-    ext = ext_map.get(language, ".py")
+    extensions = ext_map.get(language, [".py"])
 
     # Try to find the module file
     # module_path "providers/anthropic" -> providers/anthropic.py
-    module_file = project / f"{module_path}{ext}"
+    module_file = None
+    checked_paths = []
+    for ext in extensions:
+        candidate = project / f"{module_path}{ext}"
+        checked_paths.append(candidate)
+        if candidate.exists():
+            module_file = candidate
+            break
 
-    if not module_file.exists():
+    if module_file is None:
         # Try as directory with __init__.py (Python package)
         init_file = project / module_path / "__init__.py"
         if init_file.exists():
             module_file = init_file
         else:
-            raise ValueError(f"Module not found: {module_path} (tried {module_file} and {init_file})")
+            tried = ", ".join(str(path) for path in checked_paths + [init_file])
+            raise ValueError(f"Module not found: {module_path} (tried {tried})")
 
     # Extract all functions and classes from the module
     extractor = HybridExtractor()
@@ -536,7 +545,7 @@ def get_relevant_context(
         project: Path to project root
         entry_point: Function/method name (e.g., "Client.stream") or module path (e.g., "providers/anthropic")
         depth: How deep to traverse the call graph
-        language: python, typescript, go, or rust
+        language: python, typescript, javascript, go, or rust
         include_docstrings: Whether to include function docstrings
 
     Returns:
@@ -547,15 +556,6 @@ def get_relevant_context(
     # Module query mode: path with / and no . (e.g., "providers/anthropic")
     if "/" in entry_point and "." not in entry_point:
         return _get_module_exports(project, entry_point, language, include_docstrings)
-
-    # Check if entry_point is a module name (no / or .)
-    # e.g., "unified_gate" -> check for unified_gate.py
-    ext_for_lang = {
-        "python": ".py",
-        "typescript": ".ts",
-        "go": ".go",
-        "rust": ".rs"
-    }.get(language, ".py")
 
     # NOTE: Removed module-file shortcut that conflicted with function lookup.
     # If entry_point="main" matched "main.ts", it would return module exports
@@ -572,6 +572,7 @@ def get_relevant_context(
     ext_map = {
         "python": {".py"},
         "typescript": {".ts", ".tsx"},
+        "javascript": {".js", ".jsx", ".mjs", ".cjs"},
         "go": {".go"},
         "rust": {".rs"}
     }
@@ -629,6 +630,7 @@ def get_relevant_context(
     cfg_extractors = {
         "python": extract_python_cfg,
         "typescript": extract_typescript_cfg,
+        "javascript": extract_typescript_cfg,
         "go": extract_go_cfg,
         "rust": extract_rust_cfg,
         "java": extract_java_cfg,
@@ -1522,7 +1524,7 @@ def get_code_structure(
 
     Args:
         root: Root directory to analyze
-        language: Language to analyze ("python", "typescript", "go", "rust")
+        language: Language to analyze ("python", "typescript", "javascript", "go", "rust")
         max_results: Maximum number of files to analyze (default 100)
         ignore_spec: Optional pathspec.PathSpec for gitignore-style patterns
 
@@ -1547,7 +1549,7 @@ def get_code_structure(
     ext_map = {
         "python": {".py"},
         "typescript": {".ts", ".tsx"},
-        "javascript": {".js", ".jsx"},
+        "javascript": {".js", ".jsx", ".mjs", ".cjs"},
         "go": {".go"},
         "rust": {".rs"},
         "java": {".java"},

--- a/tldr/api.py
+++ b/tldr/api.py
@@ -476,7 +476,7 @@ def _get_module_exports(
         if init_file.exists():
             module_file = init_file
         else:
-            tried = ", ".join(str(path) for path in checked_paths + [init_file])
+            tried = ", ".join(str(path) for path in [*checked_paths, init_file])
             raise ValueError(f"Module not found: {module_path} (tried {tried})")
 
     # Extract all functions and classes from the module

--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -49,6 +49,8 @@ EXTENSION_TO_LANGUAGE = {
     '.tsx': 'typescript',
     '.js': 'javascript',
     '.jsx': 'javascript',
+    '.mjs': 'javascript',
+    '.cjs': 'javascript',
     '.go': 'go',
     '.rs': 'rust',
     '.c': 'c',

--- a/tldr/cross_file_calls.py
+++ b/tldr/cross_file_calls.py
@@ -154,12 +154,16 @@ class ProjectCallGraph:
         return edge in self._edges
 
 
-def _get_ts_parser():
-    """Get or create a tree-sitter TypeScript parser."""
+def _get_ts_parser(language: str = "typescript"):
+    """Get or create a tree-sitter TypeScript-family parser."""
     if not TREE_SITTER_AVAILABLE:
         raise RuntimeError("tree-sitter-typescript not available")
 
-    ts_lang = tree_sitter.Language(tree_sitter_typescript.language_typescript())
+    # JavaScript frequently includes JSX; use TSX grammar for that branch.
+    if language == "javascript":
+        ts_lang = tree_sitter.Language(tree_sitter_typescript.language_tsx())
+    else:
+        ts_lang = tree_sitter.Language(tree_sitter_typescript.language_typescript())
     parser = tree_sitter.Parser(ts_lang)
     return parser
 
@@ -418,12 +422,13 @@ def parse_imports(file_path: str | Path) -> list[dict]:
     return imports
 
 
-def parse_ts_imports(file_path: str | Path) -> list[dict]:
+def parse_ts_imports(file_path: str | Path, language: str = "typescript") -> list[dict]:
     """
-    Extract import statements from a TypeScript file.
+    Extract import statements from a TypeScript/JavaScript file.
 
     Args:
-        file_path: Path to TypeScript file
+        file_path: Path to TypeScript/JavaScript file
+        language: "typescript" or "javascript"
 
     Returns:
         List of import info dicts with keys: module, names, is_default, aliases
@@ -434,18 +439,35 @@ def parse_ts_imports(file_path: str | Path) -> list[dict]:
     file_path = Path(file_path)
     try:
         source = file_path.read_bytes()
-        parser = _get_ts_parser()
+        parser = _get_ts_parser(language)
         tree = parser.parse(source)
     except (FileNotFoundError, Exception):
         return []
 
     imports = []
+    seen_imports = set()
+
+    def add_import(import_info: dict):
+        if not import_info:
+            return
+        key = (
+            import_info.get("module"),
+            tuple(import_info.get("names", [])),
+            import_info.get("default"),
+            tuple(sorted(import_info.get("aliases", {}).items())),
+        )
+        if key in seen_imports:
+            return
+        seen_imports.add(key)
+        imports.append(import_info)
 
     def walk_tree(node):
         if node.type == "import_statement":
             import_info = _parse_ts_import_node(node, source)
-            if import_info:
-                imports.append(import_info)
+            add_import(import_info)
+        elif node.type == "variable_declarator":
+            for import_info in _parse_ts_require_declarator(node, source):
+                add_import(import_info)
         for child in node.children:
             walk_tree(child)
 
@@ -499,6 +521,99 @@ def _parse_ts_import_node(node, source: bytes) -> dict | None:
             'default': default_name,
             'aliases': aliases,
         }
+    return None
+
+
+def _parse_ts_require_declarator(node, source: bytes) -> list[dict]:
+    """Parse `const x = require('...')` and `const {x} = require('...')` forms."""
+    if node.type != "variable_declarator":
+        return []
+
+    lhs = None
+    rhs_call = None
+    for child in node.children:
+        if child.type in ("identifier", "object_pattern"):
+            lhs = child
+        elif child.type == "call_expression":
+            rhs_call = child
+
+    if lhs is None or rhs_call is None:
+        return []
+
+    module = _extract_require_module_from_call(rhs_call, source)
+    if not module:
+        return []
+
+    if lhs.type == "identifier":
+        local_name = source[lhs.start_byte:lhs.end_byte].decode("utf-8")
+        return [{
+            "module": module,
+            "names": [],
+            "default": local_name,
+            "aliases": {local_name: "*"},
+        }]
+
+    imports = []
+    if lhs.type == "object_pattern":
+        names = []
+        aliases = {}
+        for child in lhs.children:
+            if child.type == "shorthand_property_identifier_pattern":
+                name = source[child.start_byte:child.end_byte].decode("utf-8")
+                names.append(name)
+            elif child.type == "pair_pattern":
+                orig_name = None
+                alias_name = None
+                for pair_child in child.children:
+                    if pair_child.type in (
+                        "identifier",
+                        "property_identifier",
+                        "shorthand_property_identifier_pattern",
+                    ):
+                        name = source[pair_child.start_byte:pair_child.end_byte].decode("utf-8")
+                        if orig_name is None:
+                            orig_name = name
+                        else:
+                            alias_name = name
+                if orig_name:
+                    names.append(orig_name)
+                    if alias_name and alias_name != orig_name:
+                        aliases[alias_name] = orig_name
+
+        if names:
+            imports.append({
+                "module": module,
+                "names": names,
+                "default": None,
+                "aliases": aliases,
+            })
+
+    return imports
+
+
+def _extract_require_module_from_call(call_node, source: bytes) -> str | None:
+    """Extract module path from `require('module')` call expressions."""
+    if call_node.type != "call_expression":
+        return None
+
+    is_require = False
+    args_node = None
+
+    for child in call_node.children:
+        if child.type == "identifier":
+            fn_name = source[child.start_byte:child.end_byte].decode("utf-8")
+            if fn_name == "require":
+                is_require = True
+        elif child.type == "arguments":
+            args_node = child
+
+    if not is_require or args_node is None:
+        return None
+
+    for child in args_node.children:
+        if child.type == "string":
+            return source[child.start_byte:child.end_byte].decode("utf-8").strip("'\"")
+
     return None
 
 
@@ -1914,7 +2029,7 @@ def build_function_index(
         # Derive module name from file path
         # e.g., pkg/core.py -> pkg.core, utils.ts -> utils
         module_parts = list(rel_path.parts[:-1]) + [rel_path.stem]
-        module_name = '/'.join(module_parts) if language == "typescript" else '.'.join(module_parts)
+        module_name = '/'.join(module_parts) if language in ("typescript", "javascript") else '.'.join(module_parts)
 
         # Also track the simple module name (last component)
         simple_module = rel_path.stem
@@ -1922,7 +2037,9 @@ def build_function_index(
         if language == "python":
             _index_python_file(src_path, rel_path, module_name, simple_module, index)
         elif language == "typescript":
-            _index_typescript_file(src_path, rel_path, module_name, simple_module, index)
+            _index_typescript_file(src_path, rel_path, module_name, simple_module, index, language=language)
+        elif language == "javascript":
+            _index_typescript_file(src_path, rel_path, module_name, simple_module, index, language=language)
         elif language == "go":
             _index_go_file(src_path, rel_path, module_name, simple_module, index)
         elif language == "rust":
@@ -1961,14 +2078,21 @@ def _index_python_file(src_path: Path, rel_path: Path, module_name: str, simple_
             index[f"{simple_module}.{node.name}"] = str(rel_path)
 
 
-def _index_typescript_file(src_path: Path, rel_path: Path, module_name: str, simple_module: str, index: dict):
-    """Index functions and classes from a TypeScript file."""
+def _index_typescript_file(
+    src_path: Path,
+    rel_path: Path,
+    module_name: str,
+    simple_module: str,
+    index: dict,
+    language: str = "typescript",
+):
+    """Index functions and classes from a TypeScript/JavaScript file."""
     if not TREE_SITTER_AVAILABLE:
         return
 
     try:
         source = src_path.read_bytes()
-        parser = _get_ts_parser()
+        parser = _get_ts_parser(language)
         tree = parser.parse(source)
     except (FileNotFoundError, Exception):
         return
@@ -2013,6 +2137,14 @@ def _index_typescript_file(src_path: Path, rel_path: Path, module_name: str, sim
             if name:
                 add_to_index(name)
 
+        # CommonJS exports:
+        #   exports.foo = function() {}
+        #   module.exports.foo = helper
+        #   module.exports = { foo, bar: baz }
+        elif node.type == "assignment_expression":
+            for export_name in _get_commonjs_export_names(node, source):
+                add_to_index(export_name)
+
         for child in node.children:
             walk_tree(child)
 
@@ -2025,6 +2157,62 @@ def _get_ts_node_name(node, source: bytes) -> str | None:
         if child.type in ("identifier", "property_identifier", "type_identifier"):
             return source[child.start_byte:child.end_byte].decode("utf-8")
     return None
+
+
+def _get_commonjs_export_names(assign_node, source: bytes) -> list[str]:
+    """Extract exported symbol names from CommonJS assignment expressions."""
+    if assign_node.type != "assignment_expression" or len(assign_node.children) < 3:
+        return []
+
+    lhs = assign_node.children[0]
+    rhs = assign_node.children[-1]
+
+    lhs_text = source[lhs.start_byte:lhs.end_byte].decode("utf-8").replace(" ", "")
+    function_like_rhs = {
+        "function_expression",
+        "arrow_function",
+        "identifier",
+        "member_expression",
+        "class",
+        "class_declaration",
+    }
+
+    if lhs_text.startswith("exports.") and rhs.type in function_like_rhs:
+        export_name = lhs_text.split("exports.", 1)[1]
+        return [export_name] if export_name.isidentifier() else []
+
+    if lhs_text.startswith("module.exports.") and rhs.type in function_like_rhs:
+        export_name = lhs_text.split("module.exports.", 1)[1]
+        return [export_name] if export_name.isidentifier() else []
+
+    if lhs_text == "module.exports" and rhs.type == "object":
+        return _extract_commonjs_object_export_names(rhs, source)
+
+    return []
+
+
+def _extract_commonjs_object_export_names(object_node, source: bytes) -> list[str]:
+    """Extract export names from `module.exports = { ... }` object literals."""
+    export_names = []
+
+    for child in object_node.children:
+        if child.type == "shorthand_property_identifier":
+            name = source[child.start_byte:child.end_byte].decode("utf-8")
+            if name.isidentifier():
+                export_names.append(name)
+        elif child.type == "pair":
+            key_name = None
+            for pair_child in child.children:
+                if pair_child.type in ("identifier", "property_identifier"):
+                    key_name = source[pair_child.start_byte:pair_child.end_byte].decode("utf-8")
+                    break
+                if pair_child.type == "string":
+                    key_name = source[pair_child.start_byte:pair_child.end_byte].decode("utf-8").strip("'\"")
+                    break
+            if key_name and key_name.isidentifier():
+                export_names.append(key_name)
+
+    return export_names
 
 
 def _index_go_file(src_path: Path, rel_path: Path, module_name: str, simple_module: str, index: dict):
@@ -2547,7 +2735,11 @@ def _extract_file_calls(file_path: Path, root: Path) -> dict[str, list[tuple[str
     return calls_by_func
 
 
-def _extract_ts_file_calls(file_path: Path, root: Path) -> dict[str, list[tuple[str, str]]]:
+def _extract_ts_file_calls(
+    file_path: Path,
+    root: Path,
+    language: str = "typescript",
+) -> dict[str, list[tuple[str, str]]]:
     """
     Extract all function calls from a TypeScript file, grouped by caller function.
 
@@ -2560,7 +2752,7 @@ def _extract_ts_file_calls(file_path: Path, root: Path) -> dict[str, list[tuple[
 
     try:
         source = file_path.read_bytes()
-        parser = _get_ts_parser()
+        parser = _get_ts_parser(language)
         tree = parser.parse(source)
     except (FileNotFoundError, Exception):
         return {}
@@ -3300,7 +3492,9 @@ def build_project_call_graph(
     if language == "python":
         _build_python_call_graph(root, graph, func_index, workspace_config)
     elif language == "typescript":
-        _build_typescript_call_graph(root, graph, func_index, workspace_config)
+        _build_typescript_call_graph(root, graph, func_index, workspace_config, language=language)
+    elif language == "javascript":
+        _build_typescript_call_graph(root, graph, func_index, workspace_config, language=language)
     elif language == "go":
         _build_go_call_graph(root, graph, func_index, workspace_config)
     elif language == "rust":
@@ -3393,15 +3587,16 @@ def _build_typescript_call_graph(
     root: Path,
     graph: ProjectCallGraph,
     func_index: dict,
-    workspace_config: Optional[WorkspaceConfig] = None
+    workspace_config: Optional[WorkspaceConfig] = None,
+    language: str = "typescript",
 ):
-    """Build call graph for TypeScript files."""
-    for ts_file in scan_project(root, "typescript", workspace_config):
+    """Build call graph for TypeScript/JavaScript files."""
+    for ts_file in scan_project(root, language, workspace_config):
         ts_path = Path(ts_file)
         rel_path = str(ts_path.relative_to(root))
 
         # Get imports for this file
-        imports = parse_ts_imports(ts_path)
+        imports = parse_ts_imports(ts_path, language=language)
 
         # Build import resolution map
         # For TypeScript, imports are relative paths or package names
@@ -3434,7 +3629,7 @@ def _build_typescript_call_graph(
                 default_imports[imp['default']] = module_path
 
         # Get calls from this file
-        calls_by_func = _extract_ts_file_calls(ts_path, root)
+        calls_by_func = _extract_ts_file_calls(ts_path, root, language=language)
 
         for caller_func, calls in calls_by_func.items():
             for call_type, call_target in calls:

--- a/tldr/cross_file_calls.py
+++ b/tldr/cross_file_calls.py
@@ -2036,9 +2036,7 @@ def build_function_index(
 
         if language == "python":
             _index_python_file(src_path, rel_path, module_name, simple_module, index)
-        elif language == "typescript":
-            _index_typescript_file(src_path, rel_path, module_name, simple_module, index, language=language)
-        elif language == "javascript":
+        elif language in ("typescript", "javascript"):
             _index_typescript_file(src_path, rel_path, module_name, simple_module, index, language=language)
         elif language == "go":
             _index_go_file(src_path, rel_path, module_name, simple_module, index)
@@ -2233,6 +2231,30 @@ def _extract_commonjs_object_export_names(object_node, source: bytes) -> list[st
                 export_names.append(key_name)
 
     return export_names
+
+
+def _extract_commonjs_file_exports(file_path: Path, language: str = "javascript") -> set[str]:
+    """Extract CommonJS exported names for a file."""
+    if not TREE_SITTER_AVAILABLE:
+        return set()
+
+    try:
+        source = file_path.read_bytes()
+        parser = _get_ts_parser(language)
+        tree = parser.parse(source)
+    except (FileNotFoundError, Exception):
+        return set()
+
+    exports = set()
+
+    def walk_tree(node):
+        if node.type == "assignment_expression":
+            exports.update(_get_commonjs_export_names(node, source))
+        for child in node.children:
+            walk_tree(child)
+
+    walk_tree(tree.root_node)
+    return exports
 
 
 def _index_go_file(src_path: Path, rel_path: Path, module_name: str, simple_module: str, index: dict):
@@ -3516,9 +3538,7 @@ def build_project_call_graph(
 
     if language == "python":
         _build_python_call_graph(root, graph, func_index, workspace_config)
-    elif language == "typescript":
-        _build_typescript_call_graph(root, graph, func_index, workspace_config, language=language)
-    elif language == "javascript":
+    elif language in ("typescript", "javascript"):
         _build_typescript_call_graph(root, graph, func_index, workspace_config, language=language)
     elif language == "go":
         _build_go_call_graph(root, graph, func_index, workspace_config)
@@ -3616,6 +3636,8 @@ def _build_typescript_call_graph(
     language: str = "typescript",
 ):
     """Build call graph for TypeScript/JavaScript files."""
+    commonjs_exports_cache = {}
+
     for ts_file in scan_project(root, language, workspace_config):
         ts_path = Path(ts_file)
         rel_path = str(ts_path.relative_to(root))
@@ -3682,17 +3704,15 @@ def _build_typescript_call_graph(
                             default_key = (simple_module, "default")
                             if default_key in func_index:
                                 dst_file = func_index[default_key]
-                                named_candidates = {
-                                    index_key[1]
-                                    for index_key, index_path in func_index.items()
-                                    if (
-                                        isinstance(index_key, tuple)
-                                        and len(index_key) == 2
-                                        and index_key[0] == simple_module
-                                        and index_path == dst_file
-                                        and index_key[1] not in {"default", call_target}
+                                if dst_file not in commonjs_exports_cache:
+                                    commonjs_exports_cache[dst_file] = _extract_commonjs_file_exports(
+                                        root / dst_file,
+                                        language=language,
                                     )
-                                }
+                                named_candidates = (
+                                    commonjs_exports_cache[dst_file]
+                                    - {"default", call_target}
+                                )
                                 resolved_target = next(iter(named_candidates)) if len(named_candidates) == 1 else "default"
                                 graph.add_edge(rel_path, caller_func, dst_file, resolved_target)
 

--- a/tldr/cross_file_calls.py
+++ b/tldr/cross_file_calls.py
@@ -2185,10 +2185,30 @@ def _get_commonjs_export_names(assign_node, source: bytes) -> list[str]:
         export_name = lhs_text.split("module.exports.", 1)[1]
         return [export_name] if export_name.isidentifier() else []
 
+    if lhs_text == "module.exports" and rhs.type in function_like_rhs:
+        export_names = ["default"]
+        rhs_name = _get_commonjs_rhs_name(rhs, source)
+        if rhs_name and rhs_name not in export_names:
+            export_names.append(rhs_name)
+        return export_names
+
     if lhs_text == "module.exports" and rhs.type == "object":
         return _extract_commonjs_object_export_names(rhs, source)
 
     return []
+
+
+def _get_commonjs_rhs_name(rhs_node, source: bytes) -> str | None:
+    """Extract a stable symbol name from a CommonJS RHS expression when possible."""
+    if rhs_node.type == "identifier":
+        name = source[rhs_node.start_byte:rhs_node.end_byte].decode("utf-8")
+        return name if name.isidentifier() else None
+
+    if rhs_node.type in {"function_expression", "class", "class_declaration"}:
+        name = _get_ts_node_name(rhs_node, source)
+        return name if name and name.isidentifier() else None
+
+    return None
 
 
 def _extract_commonjs_object_export_names(object_node, source: bytes) -> list[str]:
@@ -2769,10 +2789,15 @@ def _extract_ts_file_calls(
         elif node.type == "lexical_declaration":
             for child in node.children:
                 if child.type == "variable_declarator":
+                    var_name = None
+                    has_local_callable_initializer = False
                     for vc in child.children:
-                        if vc.type == "identifier":
-                            defined_names.add(source[vc.start_byte:vc.end_byte].decode("utf-8"))
-                            break
+                        if vc.type == "identifier" and var_name is None:
+                            var_name = source[vc.start_byte:vc.end_byte].decode("utf-8")
+                        elif vc.type in ("arrow_function", "function_expression", "class", "class_declaration"):
+                            has_local_callable_initializer = True
+                    if var_name and has_local_callable_initializer:
+                        defined_names.add(var_name)
         for child in node.children:
             collect_definitions(child)
 
@@ -3653,6 +3678,23 @@ def _build_typescript_call_graph(
                         if key in func_index:
                             dst_file = func_index[key]
                             graph.add_edge(rel_path, caller_func, dst_file, call_target)
+                        else:
+                            default_key = (simple_module, "default")
+                            if default_key in func_index:
+                                dst_file = func_index[default_key]
+                                named_candidates = {
+                                    index_key[1]
+                                    for index_key, index_path in func_index.items()
+                                    if (
+                                        isinstance(index_key, tuple)
+                                        and len(index_key) == 2
+                                        and index_key[0] == simple_module
+                                        and index_path == dst_file
+                                        and index_key[1] not in {"default", call_target}
+                                    )
+                                }
+                                resolved_target = next(iter(named_candidates)) if len(named_candidates) == 1 else "default"
+                                graph.add_edge(rel_path, caller_func, dst_file, resolved_target)
 
                 elif call_type == 'attr':
                     parts = call_target.split('.', 1)

--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -885,6 +885,8 @@ def _detect_project_languages(project_path: Path, respect_ignore: bool = True) -
         '.tsx': 'typescript',
         '.js': 'javascript',
         '.jsx': 'javascript',
+        '.mjs': 'javascript',
+        '.cjs': 'javascript',
         '.go': 'go',
         '.rs': 'rust',
         '.c': 'c',


### PR DESCRIPTION
## Summary
- add JavaScript dispatch support to `build_function_index` and `build_project_call_graph`
- parameterize the shared TS callgraph builder so `--lang javascript` scans JS files instead of hardcoded TS-only scan
- add CommonJS import/export handling for cross-file graph resolution (`require(...)`, `exports.*`, `module.exports.*`, `module.exports = { ... }`)
- wire JavaScript into `get_relevant_context` CFG extractor mapping and extension maps (`.js/.jsx/.mjs/.cjs`)
- expand CLI/semantic extension detection for `.mjs` and `.cjs`
- add JS regression coverage in `tests/test_javascript_features.py` and update language wiring expectations

## Why
JavaScript structure parsing was present, but graph-dependent paths (`calls`, `impact`, parts of `context`) were missing dispatch/mapping support. This patch closes those gaps and adds regression tests so failures do not regress silently.

## Validation
- `PYTHONPATH=/home/adam/llm-tldr /home/adam/.local/share/pipx/venvs/llm-tldr/bin/python -m pytest tests/test_javascript_features.py -q`
- `PYTHONPATH=/home/adam/llm-tldr /home/adam/.local/share/pipx/venvs/llm-tldr/bin/python -m pytest tests/test_typescript_features.py tests/test_language_wiring.py tests/test_commonjs.py -k "not diagnostics" -q`
- `PYTHONPATH=/home/adam/llm-tldr /home/adam/.local/share/pipx/venvs/llm-tldr/bin/python -m pytest tests/ -q` (342 passed, 1 failed: `TestDiagnostics::test_diagnostics_invalid_file`, environment lacked diagnostics tools and reported `tools: []`)

## Behavior proof
Pre-fix JavaScript fixture:
- `calls` => `edges: []`
- `impact` => function not found

Post-fix JavaScript fixture:
- `calls` resolves `a.js:foo -> b.js:bar`
- `impact bar` resolves caller `a.js:foo`
- `context foo --lang javascript` includes callee expansion and CFG metrics

Post-fix CommonJS fixture:
- `require('./helper')` + `module.exports.helper` now resolves cross-file edge and impact caller.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broadened JavaScript support to include .mjs and .cjs for discovery, CLI detection, module resolution, and call-graph/context extraction; JS handling aligned with TypeScript parsing where applicable.

* **Tests**
  * Added regression tests for JS call-graph and module import/export patterns, context metrics, multi-extension resolution, and a guard to skip when tree-sitter support is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->