### PR TITLE
fix: resolve scan_project performance regression (~640x faster)

### DIFF
--- a/tldr/cross_file_calls.py
+++ b/tldr/cross_file_calls.py
@@ -293,7 +293,7 @@ def scan_project(
     Returns:
         List of absolute paths to source files
     """
-    from .tldrignore import load_ignore_patterns, should_ignore
+    from .tldrignore import load_ignore_patterns, should_ignore, filter_files
 
     root = Path(root)
     files = []
@@ -340,27 +340,42 @@ def scan_project(
 
     for dirpath, dirnames, filenames in os.walk(root):
         # Skip ignored directories (modifying dirnames in-place prunes os.walk)
+        # use_gitignore=False avoids spawning a subprocess per directory;
+        # gitignore is checked in a single batch call after file collection
         if respect_ignore and ignore_spec:
             rel_dir = os.path.relpath(dirpath, root)
             # Check if current directory should be ignored
-            if rel_dir != '.' and should_ignore(rel_dir + '/', root, ignore_spec):
+            if rel_dir != '.' and should_ignore(
+                rel_dir + '/', root, ignore_spec, use_gitignore=False
+            ):
                 dirnames.clear()  # Don't descend into ignored directories
                 continue
             # Filter subdirectories
             dirnames[:] = [
                 d for d in dirnames
-                if not should_ignore(os.path.join(rel_dir, d) + '/', root, ignore_spec)
+                if not should_ignore(
+                    os.path.join(rel_dir, d) + '/', root, ignore_spec,
+                    use_gitignore=False,
+                )
             ]
 
         for filename in filenames:
             if any(filename.endswith(ext) for ext in extensions):
                 file_path = os.path.join(dirpath, filename)
-                # Check individual file against ignore patterns
+                # Check individual file against .tldrignore patterns only
                 if respect_ignore and ignore_spec:
                     rel_path = os.path.relpath(file_path, root)
-                    if should_ignore(rel_path, root, ignore_spec):
+                    if should_ignore(
+                        rel_path, root, ignore_spec, use_gitignore=False
+                    ):
                         continue
                 files.append(file_path)
+
+    # Batch-check gitignore in a single subprocess call (instead of per-file)
+    if respect_ignore and files:
+        files = [str(f) for f in filter_files(
+            [Path(f) for f in files], root, respect_ignore=True
+        )]
 
     # Apply workspace config filtering if provided
     if workspace_config is not None:

--- a/tldr/cross_file_calls.py
+++ b/tldr/cross_file_calls.py
@@ -295,7 +295,7 @@ def scan_project(
     """
     from .tldrignore import load_ignore_patterns, should_ignore, filter_files
 
-    root = Path(root)
+    root = Path(root).resolve()
     files = []
 
     # Load ignore patterns if respecting .tldrignore

--- a/tldr/cross_file_calls.py
+++ b/tldr/cross_file_calls.py
@@ -293,7 +293,10 @@ def scan_project(
     Returns:
         List of absolute paths to source files
     """
-    from .tldrignore import load_ignore_patterns, should_ignore, filter_files
+    from .tldrignore import (
+        load_ignore_patterns, should_ignore,
+        batch_gitignored, is_git_repo, _has_negation_for_file,
+    )
 
     root = Path(root).resolve()
     files = []
@@ -371,11 +374,23 @@ def scan_project(
                         continue
                 files.append(file_path)
 
-    # Batch-check gitignore in a single subprocess call (instead of per-file)
-    if respect_ignore and files:
-        files = [str(f) for f in filter_files(
-            [Path(f) for f in files], root, respect_ignore=True
-        )]
+    # Batch-check gitignore in a single subprocess call (instead of per-file).
+    # Use batch_gitignored directly rather than filter_files, because
+    # filter_files' gitignore pass doesn't preserve .tldrignore negation (!)
+    # patterns — files explicitly un-ignored by .tldrignore must stay even
+    # when gitignored.
+    if respect_ignore and files and is_git_repo(str(root)):
+        gitignored = batch_gitignored([Path(f) for f in files], root)
+        if gitignored:
+            kept = []
+            for f in files:
+                rel = os.path.relpath(f, root)
+                if rel not in gitignored:
+                    kept.append(f)
+                elif ignore_spec and _has_negation_for_file(ignore_spec, rel):
+                    # .tldrignore negation overrides gitignore
+                    kept.append(f)
+            files = kept
 
     # Apply workspace config filtering if provided
     if workspace_config is not None:

--- a/tldr/cross_file_calls.py
+++ b/tldr/cross_file_calls.py
@@ -1934,7 +1934,7 @@ def build_function_index(
     Returns:
         Dict mapping (module, func_name) tuples to relative file paths
     """
-    root = Path(root)
+    root = Path(root).resolve()
     index = {}
 
     for src_file in scan_project(root, language, workspace_config):
@@ -3317,7 +3317,7 @@ def build_project_call_graph(
     Returns:
         ProjectCallGraph with edges as (src_file, src_func, dst_file, dst_func)
     """
-    root = Path(root)
+    root = Path(root).resolve()
     graph = ProjectCallGraph()
 
     # Load workspace config if enabled

--- a/tldr/tldrignore.py
+++ b/tldr/tldrignore.py
@@ -391,6 +391,11 @@ def should_ignore(
     if spec is None:
         spec = load_ignore_patterns(project_dir)
 
+    # Preserve trailing slash before Path() strips it — pathspec needs it
+    # to correctly match directory patterns like ".venv/" or "node_modules/"
+    orig_str = str(file_path)
+    has_trailing_slash = orig_str.endswith("/")
+
     project_path = Path(project_dir)
     file_path = Path(file_path)
 
@@ -402,6 +407,8 @@ def should_ignore(
         rel_path = file_path
 
     rel_path_str = str(rel_path)
+    if has_trailing_slash and not rel_path_str.endswith("/"):
+        rel_path_str += "/"
 
     # .tldrignore is the final authority - it can:
     # - Add ignores (positive patterns)


### PR DESCRIPTION
## Summary

Fixes #56 — `scan_project()` takes 20+ minutes on repos with large ignored directories (e.g. `.venv/` with 10k+ files).

Two compounding bugs:

1. **`Path()` strips trailing slashes, breaking pathspec directory matching.** Patterns like `.venv/` never matched because `should_ignore()` converts paths through `Path()` which removes the trailing slash. `pathspec` requires trailing slashes to match directory patterns — so `.venv` (no slash) doesn't match the `.venv/` pattern, and no directories are ever pruned from `os.walk()`.

2. **Per-file `git check-ignore` subprocess calls.** Even with directory pruning working, every source file spawns an individual `~100ms` subprocess for gitignore checking. On a repo with 537 Python source files, that's ~54 seconds just for gitignore checks — and if `.venv/` isn't pruned (bug #1), the 10k+ `.py` files inside it each spawn a subprocess too.

## Changes

- **`tldrignore.py`**: Preserve trailing slash before `Path()` conversion in `should_ignore()`, restoring it after path normalization so `pathspec` can correctly match directory patterns.
- **`cross_file_calls.py`**: Pass `use_gitignore=False` during `os.walk()` to avoid per-entry subprocesses. After file collection, batch-check gitignore via `filter_files()` which uses a single `git check-ignore --stdin` subprocess call.

## Result

| Before | After | Speedup |
|--------|-------|---------|
| 20+ minutes | 1.9 seconds | ~640x |

## Test plan

- [x] Tested on a Django project with `.venv/` (10k+ `.py` files) and 537 source files
- [x] Verified directory pruning works (`.venv/`, `node_modules/`, etc. correctly skipped)
- [x] Verified gitignore rules still respected via batch check
- [x] No behavior change for repos without large ignored directories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory-based ignore patterns (e.g., ".venv/", "node_modules/") now match and apply correctly, including negations.
  * Project scanning now resolves the project root to an absolute path to avoid missed files.
  * Per-directory ignore checks defer gitignore handling to the batch step, preserving negation behavior.

* **Performance Improvements**
  * Ignore processing consolidated into a single batch step after file collection, reducing per-directory overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->