### PR TITLE
fix: return error when context entry point not found

### DIFF
--- a/tldr/api.py
+++ b/tldr/api.py
@@ -391,9 +391,13 @@ class RelevantContext:
     entry_point: str
     depth: int
     functions: list[FunctionContext] = field(default_factory=list)
+    error: str | None = None
 
     def to_llm_string(self) -> str:
         """Format for LLM injection."""
+        if self.error:
+            return f"Error: {self.error}"
+
         lines = [
             f"## Code Context: {self.entry_point} (depth={self.depth})",
             ""
@@ -725,7 +729,15 @@ def get_relevant_context(
                     if callee not in visited and current_depth < depth:
                         queue.append((callee, current_depth + 1))
         else:
-            # Function not found in signatures, still include it
+            # Entry point not found — return error instead of phantom stub
+            if func_name == entry_point and current_depth == 0:
+                return RelevantContext(
+                    entry_point=entry_point,
+                    depth=depth,
+                    error=f"Function '{entry_point}' not found in project"
+                )
+
+            # Callee not found in signatures during BFS, still include stub
             ctx = FunctionContext(
                 name=func_name,
                 file="?",

--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -703,6 +703,9 @@ Semantic Search:
             ctx = get_relevant_context(
                 args.project, args.entry, depth=args.depth, language=args.lang
             )
+            if ctx.error:
+                print(ctx.to_llm_string(), file=sys.stderr)
+                sys.exit(1)
             # Output LLM-ready string directly
             print(ctx.to_llm_string())
 


### PR DESCRIPTION
## Summary
- `tldr context` previously fabricated phantom stubs (`def funcname(...)` at `?:0`) when a function didn't exist in the project, with exit code 0
- Now returns `Error: Function 'X' not found in project` on stderr with exit code 1
- BFS callee stubs (depth > 0) are preserved — they handle legitimately unparseable referenced code

## Motivation
AI agents (Claude Code subagents) were trusting phantom output as real function definitions. Mining 351 session files (~1.2GB) across 3 projects showed agents could not distinguish real from fabricated context output. This caused wasted turns and incorrect reasoning.

## Changes
- `api.py`: Added `error` field to `RelevantContext` dataclass + early return when entry point not found at depth 0
- `cli.py`: Error handling in context command — prints to stderr, exits with code 1

## Test plan
- [x] `tldr context DaemonState --project . --depth 2 --lang rust` → works, shows real function
- [x] `tldr context totally_fake_xyz --project . --depth 2 --lang rust` → `Error: Function 'totally_fake_xyz' not found in project`, exit 1
- [x] `tldr context nonexistent --project . --depth 2` → same error behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit error messages when entry points cannot be resolved, providing better feedback to users.

* **Bug Fixes**
  * Tool now exits with appropriate error status code when resolution failures occur.
  * Missing entry points now generate clear error messages instead of proceeding silently with incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->