### PR TITLE
fix: error on file paths in search, document --ignore flag

### DIFF
--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -203,7 +203,11 @@ Semantic Search:
     )
 
     # tldr search <pattern> [path]
-    search_p = subparsers.add_parser("search", help="Search files for pattern")
+    search_p = subparsers.add_parser(
+        "search",
+        help="Search files for pattern",
+        description="Search files for a regex pattern. Use the global --ignore PATTERN flag to exclude directories from search.",
+    )
     search_p.add_argument("pattern", help="Regex pattern to search")
     search_p.add_argument("path", nargs="?", default=".", help="Directory to search")
     search_p.add_argument("--ext", nargs="+", help="Filter by extensions")
@@ -639,6 +643,9 @@ Semantic Search:
             print(json.dumps(combined_result, indent=2))
 
         elif args.command == "search":
+            if Path(args.path).is_file():
+                print(f"Error: '{args.path}' is a file, not a directory. Use a directory path for search.", file=sys.stderr)
+                sys.exit(1)
             ext = set(args.ext) if args.ext else None
             ignore_spec = get_ignore_spec(args.path)
             result = api_search(


### PR DESCRIPTION
## Summary
- `tldr search "pattern" some_file.rs` previously returned `[]` silently with exit code 0
- Now prints `Error: 'some_file.rs' is a file, not a directory` to stderr with exit code 1
- Added `--ignore PATTERN` mention to `search --help` for discoverability

## Motivation
Mining 351 AI agent session files showed **123 file-level `tldr search` invocations** (14.4% of all searches) that silently returned empty results. Agents wasted turns getting nothing, then had to retry with broader paths. The `--ignore` global flag was also undiscoverable from `search --help`.

## Changes
- `cli.py`: `Path.is_file()` guard before search execution
- `cli.py`: Updated search subparser description to mention `--ignore`

## Test plan
- [x] `tldr search "DaemonState" src/daemon_state.rs` → clear error, exit 1
- [x] `tldr search "DaemonState" src/` → works normally, exit 0
- [x] `tldr search "DaemonState" .` → works normally, exit 0
- [x] `tldr search --help` → shows `--ignore` mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The search command now validates that the provided path is a directory and exits with an error if a file is provided instead.

* **Documentation**
  * Improved help text for the search subcommand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->