### PR TITLE
fix(semantic): suppress HuggingFace model-loading noise in get_model()

### DIFF
--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -178,9 +178,10 @@ def _confirm_download(model_key: str) -> bool:
 def _suppress_hf_noise():
     """Suppress HuggingFace/tqdm noise emitted during model weight loading.
 
-    Sets env vars for libraries not yet imported, and calls the huggingface_hub
-    programmatic API for the progress-bar state (which is frozen in a module-level
-    constant and cannot be changed via env vars after first import).
+    Sets env vars for libraries not yet imported, and attempts to call the
+    huggingface_hub programmatic API for the progress-bar state (which is
+    frozen in a module-level constant and cannot be changed via env vars after
+    first import). If the import fails, suppression gracefully degrades (best-effort).
 
     TOKENIZERS_PARALLELISM is set defensively: ProcessPoolExecutor forks worker
     processes before get_model() is called, so no active tokenizer pool exists at
@@ -195,15 +196,18 @@ def _suppress_hf_noise():
         os.environ.update(_HF_NOISE_SUPPRESSIONS)
         # huggingface_hub.utils.tqdm caches HF_HUB_DISABLE_PROGRESS_BARS at import time,
         # so env vars alone are insufficient once it is imported. Use the programmatic API.
-        from huggingface_hub.utils.tqdm import (
-            are_progress_bars_disabled,
-            disable_progress_bars,
-            enable_progress_bars,
-        )
-        _enable_progress_bars = enable_progress_bars
-        _bars_were_disabled = are_progress_bars_disabled()
-        if not _bars_were_disabled:
-            disable_progress_bars()
+        try:
+            from huggingface_hub.utils.tqdm import (
+                are_progress_bars_disabled,
+                disable_progress_bars,
+                enable_progress_bars,
+            )
+            _bars_were_disabled = are_progress_bars_disabled()
+            if not _bars_were_disabled:
+                disable_progress_bars()
+                _enable_progress_bars = enable_progress_bars
+        except (ImportError, AttributeError):
+            pass  # best-effort: if import fails, skip progress-bar suppression
         yield
     finally:
         for key in _HF_NOISE_SUPPRESSIONS:
@@ -212,7 +216,7 @@ def _suppress_hf_noise():
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = val
-        if not _bars_were_disabled and _enable_progress_bars is not None:
+        if _enable_progress_bars is not None:
             _enable_progress_bars()
 
 

--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -197,7 +197,7 @@ def _suppress_hf_noise():
         # huggingface_hub.utils.tqdm caches HF_HUB_DISABLE_PROGRESS_BARS at import time,
         # so env vars alone are insufficient once it is imported. Use the programmatic API.
         try:
-            from huggingface_hub.utils.tqdm import (
+            from huggingface_hub.utils import (
                 are_progress_bars_disabled,
                 disable_progress_bars,
                 enable_progress_bars,

--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -20,7 +20,7 @@ import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Tuple, Dict, Any
+from typing import Iterator, List, Optional, Tuple, Dict, Any
 
 logger = logging.getLogger("tldr.semantic")
 
@@ -175,7 +175,7 @@ def _confirm_download(model_key: str) -> bool:
 
 
 @contextlib.contextmanager
-def _suppress_hf_noise():
+def _suppress_hf_noise() -> Iterator[None]:
     """Suppress HuggingFace/tqdm noise emitted during model weight loading.
 
     Sets env vars for libraries not yet imported, and attempts to call the

--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -12,6 +12,7 @@ Uses BAAI/bge-large-en-v1.5 for embeddings (1024 dimensions)
 and FAISS for fast vector similarity search.
 """
 
+import contextlib
 import json
 import logging
 import os
@@ -25,6 +26,12 @@ logger = logging.getLogger("tldr.semantic")
 
 ALL_LANGUAGES = ["python", "typescript", "javascript", "go", "rust", "java", "c", "cpp", "ruby", "php", "kotlin", "swift", "csharp", "scala", "lua", "luau", "elixir"]
 
+_HF_NOISE_SUPPRESSIONS = {
+    "TRANSFORMERS_VERBOSITY": "error",
+    "TOKENIZERS_PARALLELISM": "false",
+    "TQDM_DISABLE": "1",
+    "HF_HUB_DISABLE_PROGRESS_BARS": "1",
+}
 # Lazy imports for heavy dependencies
 _model = None
 _model_name = None  # Track which model is loaded
@@ -167,6 +174,48 @@ def _confirm_download(model_key: str) -> bool:
         return False
 
 
+@contextlib.contextmanager
+def _suppress_hf_noise():
+    """Suppress HuggingFace/tqdm noise emitted during model weight loading.
+
+    Sets env vars for libraries not yet imported, and calls the huggingface_hub
+    programmatic API for the progress-bar state (which is frozen in a module-level
+    constant and cannot be changed via env vars after first import).
+
+    TOKENIZERS_PARALLELISM is set defensively: ProcessPoolExecutor forks worker
+    processes before get_model() is called, so no active tokenizer pool exists at
+    this point. The env var is set preemptively in case a tokenizer is initialised
+    inside the context body, not to suppress a warning that is already occurring.
+    """
+    saved = {key: os.environ.pop(key, None) for key in _HF_NOISE_SUPPRESSIONS}
+    _bars_were_disabled = False
+    _enable_progress_bars = None
+
+    try:
+        os.environ.update(_HF_NOISE_SUPPRESSIONS)
+        # huggingface_hub.utils.tqdm caches HF_HUB_DISABLE_PROGRESS_BARS at import time,
+        # so env vars alone are insufficient once it is imported. Use the programmatic API.
+        from huggingface_hub.utils.tqdm import (
+            are_progress_bars_disabled,
+            disable_progress_bars,
+            enable_progress_bars,
+        )
+        _enable_progress_bars = enable_progress_bars
+        _bars_were_disabled = are_progress_bars_disabled()
+        if not _bars_were_disabled:
+            disable_progress_bars()
+        yield
+    finally:
+        for key in _HF_NOISE_SUPPRESSIONS:
+            val = saved[key]
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+        if not _bars_were_disabled and _enable_progress_bars is not None:
+            _enable_progress_bars()
+
+
 def get_model(model_name: Optional[str] = None):
     """Lazy-load the embedding model (cached).
 
@@ -203,8 +252,9 @@ def get_model(model_name: Optional[str] = None):
         if model_key and not _confirm_download(model_key):
             raise ValueError(f"Model download declined. Use --model to choose a smaller model.")
 
-    from sentence_transformers import SentenceTransformer
-    _model = SentenceTransformer(hf_name)
+    with _suppress_hf_noise():
+        from sentence_transformers import SentenceTransformer
+        _model = SentenceTransformer(hf_name)
     _model_name = hf_name
     return _model
 

--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -20,7 +20,8 @@ import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterator, List, Optional, Tuple, Dict, Any
+from collections.abc import Iterator
+from typing import List, Optional, Tuple, Dict, Any
 
 logger = logging.getLogger("tldr.semantic")
 


### PR DESCRIPTION
## Summary

- Adds `_suppress_hf_noise()` context manager that silences three noisy stderr lines emitted during cold load of `BAAI/bge-large-en-v1.5`: the tqdm `Loading weights` progress bar, `BertModel LOAD REPORT`, and `embeddings.position_ids | UNEXPECTED` key warning
- Uses dual suppression: four env vars + `huggingface_hub.utils.tqdm.disable_progress_bars()` programmatic API (env vars alone are insufficient because the HF constant is frozen at module import time)
- Moves the lazy `sentence_transformers` import inside the `with _suppress_hf_noise():` block so `transformers` initialises with the vars already active
- Env vars are saved/restored in a `try/finally` block with exception safety; `enable_progress_bars()` is restored in the same `finally`

## Test plan

- [ ] Run `tldr semantic search 'query' --path /path/to/project` — confirm no noise on stderr
- [ ] Run a second time (warm cache) — confirm no noise
- [ ] Run `tldr semantic index --path /path/to/project` — confirm no noise during index build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced console noise during model loading by temporarily suppressing progress bars and related runtime messages. Suppression is applied only while models initialize, attempts to disable progress indicators programmatically when available, gracefully degrades if the programmatic API is missing, and reliably restores normal output afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->