### PR TITLE
feat(semantic): default index to CPU, add --device to search

### DIFF
--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -385,6 +385,13 @@ Semantic Search:
         default=None,
         help="Embedding model: bge-large-en-v1.5 (1.3GB, default) or all-MiniLM-L6-v2 (80MB)",
     )
+    index_p.add_argument(
+        "--device",
+        default=None,
+        choices=["cpu", "metal"],
+        help="Compute device for embedding inference: 'cpu' or 'metal'. "
+             "If omitted, falls back to TLDR_DEVICE env var, then to 'cpu'.",
+    )
 
     # tldr semantic search <query>
     search_p = semantic_sub.add_parser("search", help="Search semantically")
@@ -397,6 +404,13 @@ Semantic Search:
         "--model",
         default=None,
         help="Embedding model (uses index model if not specified)",
+    )
+    search_p.add_argument(
+        "--device",
+        default=None,
+        choices=["cpu", "metal"],
+        help="Compute device for embedding inference: 'cpu' or 'metal'. "
+             "If omitted, falls back to TLDR_DEVICE env var, then to PyTorch auto-pick.",
     )
 
     # tldr daemon start/stop/status/query
@@ -564,6 +578,27 @@ Semantic Search:
                 return data.get("languages")
             except (json.JSONDecodeError, OSError):
                 pass
+        return None
+
+    def _resolve_device(args_device: str | None) -> str | None:
+        """Resolve compute device: CLI arg > TLDR_DEVICE env > None (auto-pick).
+
+        The CLI subcommand's argparse default supplies the per-command default
+        (e.g. 'cpu' for index). Validates TLDR_DEVICE if set; exits with code 2
+        on invalid env value. Returns 'cpu', 'metal', or None.
+        """
+        if args_device is not None:
+            return args_device
+        env_device = os.environ.get("TLDR_DEVICE")
+        if env_device:
+            if env_device not in ("cpu", "metal"):
+                print(
+                    f"tldr: error: TLDR_DEVICE: invalid choice: {env_device!r} "
+                    f"(choose from 'cpu', 'metal')",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            return env_device
         return None
 
     def resolve_language(lang_arg: str, project_path: str | Path) -> str:
@@ -866,7 +901,6 @@ Semantic Search:
                 print(json.dumps(result, indent=2))
 
         elif args.command == "warm":
-            import os
             import subprocess
             import time
 
@@ -969,16 +1003,22 @@ Semantic Search:
 
             if args.action == "index":
                 respect_ignore = not getattr(args, 'no_ignore', False)
-                count = build_semantic_index(args.path, lang=args.lang, model=args.model, respect_ignore=respect_ignore)
+                device = _resolve_device(getattr(args, "device", None)) or "cpu"
+                count = build_semantic_index(
+                    args.path, lang=args.lang, model=args.model,
+                    respect_ignore=respect_ignore, device=device,
+                )
                 print(f"Indexed {count} code units")
 
             elif args.action == "search":
+                device = _resolve_device(getattr(args, "device", None))
                 results = semantic_search(
                     args.path,
                     args.query,
                     k=args.k,
                     expand_graph=args.expand,
                     model=args.model,
+                    device=device,
                 )
                 print(json.dumps(results, indent=2))
 

--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -28,6 +28,15 @@ ALL_LANGUAGES = ["python", "typescript", "javascript", "go", "rust", "java", "c"
 # Lazy imports for heavy dependencies
 _model = None
 _model_name = None  # Track which model is loaded
+_model_device = None  # Track which device the cached model is on
+
+# Import SentenceTransformer at module level so it loads before faiss —
+# on macOS the reverse order triggers a libomp/OpenMP conflict that
+# segfaults during CPU encode.
+try:
+    from sentence_transformers import SentenceTransformer as _SentenceTransformer
+except ImportError:
+    _SentenceTransformer = None
 
 # Supported models with approximate download sizes
 SUPPORTED_MODELS = {
@@ -167,12 +176,14 @@ def _confirm_download(model_key: str) -> bool:
         return False
 
 
-def get_model(model_name: Optional[str] = None):
+def get_model(model_name: Optional[str] = None, *, device: Optional[str] = None):
     """Lazy-load the embedding model (cached).
 
     Args:
         model_name: Model key from SUPPORTED_MODELS, or None for default.
                    Can also be a full HuggingFace model name.
+        device: 'cpu' or 'metal' (mapped to 'mps'). If None, the env var
+                TLDR_DEVICE is consulted; if neither is set, PyTorch auto-picks.
 
     Returns:
         SentenceTransformer model instance.
@@ -180,7 +191,17 @@ def get_model(model_name: Optional[str] = None):
     Raises:
         ValueError: If model not found or user declines download.
     """
-    global _model, _model_name
+    global _model, _model_name, _model_device
+
+    if device is None:
+        env_device = os.environ.get("TLDR_DEVICE")
+        if env_device in ("cpu", "metal", "mps"):
+            device = env_device
+
+    # Canonicalize: 'metal' -> 'mps' so cache identity isn't fragmented when
+    # the same backend is requested under different spellings.
+    if device == "metal":
+        device = "mps"
 
     # Resolve model name
     if model_name is None:
@@ -193,8 +214,8 @@ def get_model(model_name: Optional[str] = None):
         # Allow arbitrary HuggingFace model names
         hf_name = model_name
 
-    # Return cached model if same
-    if _model is not None and _model_name == hf_name:
+    # Return cached model if same (key includes device)
+    if _model is not None and _model_name == hf_name and _model_device == device:
         return _model
 
     # Check if model needs downloading
@@ -203,9 +224,16 @@ def get_model(model_name: Optional[str] = None):
         if model_key and not _confirm_download(model_key):
             raise ValueError(f"Model download declined. Use --model to choose a smaller model.")
 
-    from sentence_transformers import SentenceTransformer
-    _model = SentenceTransformer(hf_name)
+    if _SentenceTransformer is None:
+        from sentence_transformers import SentenceTransformer as ST
+    else:
+        ST = _SentenceTransformer
+    if device is not None:
+        _model = ST(hf_name, device=device)
+    else:
+        _model = ST(hf_name)
     _model_name = hf_name
+    _model_device = device
     return _model
 
 
@@ -262,19 +290,21 @@ def build_embedding_text(unit: EmbeddingUnit) -> str:
     return "\n".join(parts)
 
 
-def compute_embedding(text: str, model_name: Optional[str] = None):
+def compute_embedding(text: str, model_name: Optional[str] = None, *, device: Optional[str] = None):
     """Compute embedding vector for text.
 
     Args:
         text: The text to embed.
         model_name: Model to use (from SUPPORTED_MODELS or HF name).
+        device: Compute device ('cpu' or 'metal'). If None, get_model
+            falls back to TLDR_DEVICE env or auto-pick.
 
     Returns:
         numpy array with L2-normalized embedding.
     """
     import numpy as np
 
-    model = get_model(model_name)
+    model = get_model(model_name, device=device)
 
     # BGE models work best with instruction prefix for queries
     # For document embedding, we use text directly
@@ -936,6 +966,8 @@ def build_semantic_index(
     model: Optional[str] = None,
     show_progress: bool = True,
     respect_ignore: bool = True,
+    *,
+    device: Optional[str] = None,
 ) -> int:
     """Build and save FAISS index + metadata for a project.
 
@@ -949,6 +981,8 @@ def build_semantic_index(
         model: Model name from SUPPORTED_MODELS or HuggingFace name.
         show_progress: Show progress spinner (default: True).
         respect_ignore: If True, respect .tldrignore patterns (default True).
+        device: Compute device ('cpu' or 'metal'). If None, falls back to
+                TLDR_DEVICE env var; if neither is set, PyTorch auto-picks.
 
     Returns:
         Number of indexed units.
@@ -956,6 +990,9 @@ def build_semantic_index(
     import faiss
     import numpy as np
     from tldr.tldrignore import ensure_tldrignore
+
+    if device is None:
+        device = os.environ.get("TLDR_DEVICE") or "cpu"
 
     console = _get_progress_console() if show_progress else None
 
@@ -1033,7 +1070,7 @@ def build_semantic_index(
         ) as progress:
             task = progress.add_task("Computing embeddings...", total=num_units)
 
-            model_obj = get_model(model)
+            model_obj = get_model(model, device=device)
             all_embeddings = []
 
             for i in range(0, num_units, BATCH_SIZE):
@@ -1056,7 +1093,7 @@ def build_semantic_index(
 
             embeddings_matrix = np.vstack(all_embeddings)
     else:
-        model_obj = get_model(model)
+        model_obj = get_model(model, device=device)
         result = model_obj.encode(
             texts,
             batch_size=BATCH_SIZE,
@@ -1094,6 +1131,8 @@ def semantic_search(
     k: int = 5,
     expand_graph: bool = False,
     model: Optional[str] = None,
+    *,
+    device: Optional[str] = None,
 ) -> List[dict]:
     """Search for code units semantically.
 
@@ -1104,6 +1143,8 @@ def semantic_search(
         expand_graph: If True, include callers/callees in results.
         model: Model to use for query embedding. If None, uses
                the model from the index metadata.
+        device: Compute device ('cpu' or 'metal'). If None, falls back to
+                TLDR_DEVICE env var; if neither is set, PyTorch auto-picks.
 
     Returns:
         List of result dictionaries with name, file, line, score, etc.
@@ -1142,7 +1183,7 @@ def semantic_search(
 
     # Embed query (with instruction prefix for BGE)
     query_text = f"Represent this code search query: {query}"
-    query_embedding = compute_embedding(query_text, model_name=model)
+    query_embedding = compute_embedding(query_text, model_name=model, device=device)
     query_embedding = query_embedding.reshape(1, -1)
 
     # Search


### PR DESCRIPTION
## Motivation

We want to be able to index huge projects / monorepos without the GPU spinning the fans up the whole time — but still get fast MPS-powered search for one-shot queries. The current default lets PyTorch auto-pick the device, which lands on MPS for both paths on Apple Silicon. That's great for search (one short forward pass) but punishing for long indexing runs: sustained ~27W draws the fans well past 3000 RPM on an M4 Pro for ~6 hours on a 514k-chunk corpus.

This PR flips the defaults: indexing is CPU-quiet by default; search stays GPU-fast. Both keep an explicit `--device` flag so power users can opt in to whichever backend they want. CPU indexing keeps fans peak ~2705 RPM at ~11W p50 with bge-large-en-v1.5, and the resulting vectors are cosine-compatible (~1e-5) with MPS-encoded queries, so the index/search split works end-to-end.

## Summary

- Add `--device {cpu,metal}` to `tldr semantic search` (previously only on `tldr semantic index`)
- Default `tldr semantic index --device` to `cpu` so indexing is fan-quiet by default
- Add `_resolve_device()` helper consolidating flag > `TLDR_DEVICE` env > default precedence
- Thread keyword-only `device=None` through `compute_embedding` and `semantic_search`
- Fix bug where the non-progress path of `build_semantic_index` dropped the `device` kwarg when calling `get_model`

Precedence everywhere: explicit `--device` > `TLDR_DEVICE` env > subcommand default (cpu for index; None/auto for search → PyTorch picks MPS on Apple Silicon).

## Test plan

- [ ] Full pytest suite passes locally (349 tests after this session)
- [ ] `tldr semantic index <dir>` with no flag/env → uses CPU
- [ ] `tldr semantic index <dir> --device metal` → uses MPS
- [ ] `tldr semantic search "q"` with no flag/env → uses MPS (or PyTorch auto-pick)
- [ ] `tldr semantic search "q" --device cpu` → uses CPU
- [ ] `TLDR_DEVICE=cpu tldr semantic search "q"` → uses CPU (env override)
- [ ] Explicit `--device` overrides env when both are set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --device option to semantic index and semantic search to select embedding compute device (index defaults to cpu; search falls back to env or auto-pick).
  * Embedding/model execution now respects the chosen device so indexes and queries remain compatible.

* **Bug Fixes**
  * CLI reports and exits on unsupported TLDR_DEVICE values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parcadei/llm-tldr/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->