### PR TITLE
fix(semantic): suppress transformers/hf_hub tqdm bar on cold model load

### DIFF
--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -12,10 +12,12 @@ Uses BAAI/bge-large-en-v1.5 for embeddings (1024 dimensions)
 and FAISS for fast vector similarity search.
 """
 
+import contextlib
 import json
 import logging
 import os
 import sys
+from collections.abc import Iterator
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -167,6 +169,56 @@ def _confirm_download(model_key: str) -> bool:
         return False
 
 
+@contextlib.contextmanager
+def _suppress_hf_noise() -> Iterator[None]:
+    """Suppress huggingface_hub and transformers progress bars and warnings during model load.
+
+    Disables progress bars, warnings, and verbosity for transformers and
+    huggingface_hub libraries during the block; unconditionally re-enables
+    progress bars on exit (environment variables are restored to their prior values).
+    """
+    env_keys = {
+        "TRANSFORMERS_VERBOSITY": "error",
+        "HF_HUB_DISABLE_PROGRESS_BARS": "1",
+        "TRANSFORMERS_NO_ADVISORY_WARNINGS": "1",
+    }
+    saved_env = {k: os.environ.get(k) for k in env_keys}
+    os.environ.update(env_keys)
+
+    tf_logging = None
+    try:
+        from transformers.utils import logging as tf_logging  # type: ignore
+        tf_logging.disable_progress_bar()  # type: ignore[attr-defined]
+    except (ImportError, AttributeError):
+        tf_logging = None
+
+    hf_hub_utils = None
+    try:
+        import huggingface_hub.utils as hf_hub_utils  # type: ignore
+        hf_hub_utils.disable_progress_bars()  # type: ignore[attr-defined]
+    except (ImportError, AttributeError):
+        hf_hub_utils = None
+
+    try:
+        yield
+    finally:
+        if tf_logging is not None:
+            try:
+                tf_logging.enable_progress_bar()
+            except (ImportError, AttributeError):
+                pass
+        if hf_hub_utils is not None:
+            try:
+                hf_hub_utils.enable_progress_bars()
+            except (ImportError, AttributeError):
+                pass
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
 def get_model(model_name: Optional[str] = None):
     """Lazy-load the embedding model (cached).
 
@@ -203,8 +255,9 @@ def get_model(model_name: Optional[str] = None):
         if model_key and not _confirm_download(model_key):
             raise ValueError(f"Model download declined. Use --model to choose a smaller model.")
 
-    from sentence_transformers import SentenceTransformer
-    _model = SentenceTransformer(hf_name)
+    with _suppress_hf_noise():
+        from sentence_transformers import SentenceTransformer
+        _model = SentenceTransformer(hf_name)
     _model_name = hf_name
     return _model
 


### PR DESCRIPTION
## Summary

`tldr semantic search` leaked a `Loading weights:` tqdm progress bar to stderr from `transformers/core_model_loading.py` on every cold model load. When the CLI is run by an LLM agent that pipes stderr into context, the bar polluted ~25 tokens per cold call — across thousands of invocations that's measurable context-window noise.

This change introduces a `_suppress_hf_noise()` context manager in `tldr/semantic.py` that disables progress bars on both code paths:

- `transformers.utils.logging.disable_progress_bar()` — the actual source of the leak (`tqdm.auto` cached at import time, so env-only suppression is a no-op).
- `huggingface_hub.utils.disable_progress_bars()` — defensive coverage for hf_hub's own bars.
- Env-var fallbacks (`TRANSFORMERS_VERBOSITY=error`, `HF_HUB_DISABLE_PROGRESS_BARS=1`) for paths that read them at startup.

Imports are guarded with `try/except (ImportError, AttributeError)` so older versions of either library still work. The `SentenceTransformer` import + construction in `get_model()` are wrapped in the context manager.

## Test plan

- [x] Cold `tldr semantic search "anything" --path . 2>&1 | head -1` returns the first line of JSON output (not `Loading weights: …`).
- [x] Existing test suite still passes (337 → 338 with regression test).
- [x] `huggingface_hub` `Downloading:` / `Fetching:` bars also absent.
- [x] Non-semantic subcommands (`tldr extract`, `tldr search`) output unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Reduced console noise and suppressed unnecessary progress indicators and warnings during model initialization, providing a cleaner terminal experience when launching the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parcadei/llm-tldr/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->