### PR TITLE
feat(search): accept a single file path

### DIFF
--- a/tldr/api.py
+++ b/tldr/api.py
@@ -1365,8 +1365,12 @@ def search(
 
     Args:
         pattern: Regex pattern to search for
-        root: Root directory to search in
-        extensions: Optional set of extensions to filter (e.g., {".py"})
+        root: Directory to search recursively, OR a single file to search.
+              When ``root`` is a file, ``extensions`` is ignored (explicit file
+              beats filter) and ignore_spec / hidden-dir / SKIP_DIRS gating are
+              skipped. The ``file`` field in each result is the file's basename.
+        extensions: Optional set of extensions to filter (e.g., {".py"}).
+            Ignored when ``root`` is a file path.
         context_lines: Number of context lines to include (default 0)
         max_results: Maximum matches to return (default 100, 0 = unlimited)
         max_files: Maximum files to scan (default 10000, 0 = unlimited)
@@ -1398,6 +1402,30 @@ def search(
     root = Path(root)
     compiled = re.compile(pattern)
     files_scanned = 0
+
+    # Single-file mode: user named an explicit file path. Skip rglob, ignore
+    # gating, and the extensions filter — explicit beats filter.
+    if root.is_file():
+        try:
+            content = root.read_text(encoding="utf-8", errors="ignore")
+            lines = content.splitlines()
+            for i, line in enumerate(lines, 1):
+                if compiled.search(line):
+                    match = {
+                        "file": root.name,
+                        "line": i,
+                        "content": line.strip(),
+                    }
+                    if context_lines > 0:
+                        start = max(0, i - 1 - context_lines)
+                        end = min(len(lines), i + context_lines)
+                        match["context"] = lines[start:end]
+                    results.append(match)
+                    if max_results > 0 and len(results) >= max_results:
+                        return results
+        except OSError:
+            pass
+        return results
 
     for file_path in root.rglob("*"):
         # Check file limit

--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -639,8 +639,15 @@ Semantic Search:
             print(json.dumps(combined_result, indent=2))
 
         elif args.command == "search":
+            search_path = Path(args.path)
+            if not search_path.exists():
+                print(f"Error: path '{args.path}' not found", file=sys.stderr)
+                sys.exit(1)
             ext = set(args.ext) if args.ext else None
-            ignore_spec = get_ignore_spec(args.path)
+            # When search_path is a single file, api_search ignores --ext
+            # (explicit file beats filter) and ignore_spec is rooted at parent.
+            ignore_root = search_path.parent if search_path.is_file() else search_path
+            ignore_spec = get_ignore_spec(str(ignore_root))
             result = api_search(
                 args.pattern, args.path,
                 extensions=ext,


### PR DESCRIPTION
## Summary

`tldr search PATTERN file.py` now searches the named file directly, instead of erroring out and forcing a `dirname` retry or a fallback to `grep`. This eliminates a recurring agent failure mode — at scale, ~3% of `tldr search` invocations were file paths the user had already narrowed to.

## Behaviour when `path` is a file

- `api.search()` yields the file as the only candidate; the `file` field in each match is the basename (relative to the file's parent).
- `--ext` is **ignored** for explicit file paths (explicit beats filter — searching the file the user named is what they always meant).
- `ignore_spec`, hidden-dir, and `SKIP_DIRS` gating are skipped (the user overrode conventions deliberately by naming the file).
- `--max`, `--context`, regex, and JSON output shape work identically.

## CLI changes

- Replaced the file-rejecting branch with a generic `Error: path 'X' not found` guard (stderr, exit 1) that also catches non-existent directories.
- `get_ignore_spec()` is rooted at `path.parent` when `path` is a file.

## What did NOT change

Directory-mode search behaviour is byte-for-byte the same — the new `is_file()` branch is an early return; the existing `rglob` loop is untouched.

## Test plan

- [x] 13 new behaviour tests + 6 regression-guard tests (single file, missing path, `--ext` bypass, `SKIP_DIRS` bypass, context lines, binary files, directory-mode regression)
- [x] Full local suite green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added single-file search capability: search a specific file directly instead of the entire project, with optional surrounding context lines in results.

* **Improvements**
  * Enhanced path validation and ignore pattern handling for file-based searches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parcadei/llm-tldr/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->